### PR TITLE
Common action states and variants

### DIFF
--- a/en/shared.json
+++ b/en/shared.json
@@ -35,6 +35,256 @@
   },
   "incompatible": "Incompatible",
   "compatible": "Compatible",
-  "public":"Public",
-  "private":"Private"
+  "public": "Public",
+  "private": "Private",
+
+  "commonActionStates": {
+    "yes": "Yes",
+    "no": "No",
+    "go": "Go",
+    "proceedWithEllipsis": "Proceed...",
+    "proceed": "Proceed",
+    "inProgress": "In progress...",
+    "failed": "Failed",
+    "pending": "Pending",
+    "doneWithExclamation": "Done!",
+    "done": "Done",
+
+    "complete": {
+      "completeWithEllipsis": "Complete...",
+      "complete": "Complete",
+      "completingWithEllipsis": "Completing...",
+      "completing": "Completing",
+      "completedWithExclamation": "Completed!",
+      "completed": "Completed"
+    },
+
+    "cancel": {
+      "cancelWithEllipsis": "Cancel...",
+      "cancel": "Cancel",
+      "cancelingWithEllipsis": "Canceling...",
+      "canceling": "Canceling",
+      "canceled": "Canceled"
+    },
+
+    "back": {
+      "backWithEllipsis": "Back...",
+      "back": "Back"
+    },
+
+    "close": {
+      "closeWithEllipsis": "Close...",
+      "close": "Close",
+      "closingWithEllipsis": "Closing...",
+      "closing": "Closing",
+      "closedWithExclamation": "Closed!",
+      "closed": "Closed"
+    },
+
+    "delete": {
+      "deleteWithEllipsis": "Delete...",
+      "delete": "Delete",
+      "deletingWithEllipsis": "Deleting...",
+      "deleting": "Deleting",
+      "deletedWithExclamation": "Deleted!",
+      "deleted": "Deleted"
+    },
+
+    "retry": {
+      "retryWithEllipsis": "Retry...",
+      "retry": "Retry",
+      "retryingWithEllipsis": "Retrying...",
+      "retrying": "Retrying"
+    },
+
+    "refresh": {
+      "refreshWithEllipsis": "Refresh...",
+      "refresh": "Refresh",
+      "refreshingWithEllipsis": "Refreshing...",
+      "refreshing": "Refreshing",
+      "refreshedWithExclamation": "Refreshed!",
+      "refreshed": "Refreshed"
+    },
+
+    "confirm": {
+      "confirm": "Confirm",
+      "confirmingWithEllipsis": "Confirming...",
+      "confirming": "Confirming",
+      "confirmedWithExclamation": "Confirmed!",
+      "confirmed": "Confirmed"
+    },
+
+    "copy": {
+      "copyWithEllipsis": "Copy...",
+      "copy": "Copy",
+      "copyingWithEllipsis": "Copying...",
+      "copying": "Copying",
+      "copiedWithExclamation": "Copied!",
+      "copied": "Copied"
+    },
+
+    "edit": {
+      "editWithEllipsis": "Edit...",
+      "edit": "Edit",
+      "editingWithEllipsis": "Editing...",
+      "editing": "Editing",
+      "editedWithExclamation": "Edited!",
+      "edited": "Edited"
+    },
+
+    "load": {
+      "loadWithEllipsis": "Load...",
+      "load": "Load",
+      "loadingWithEllipsis": "Loading...",
+      "loading": "Loading",
+      "loadedWithExclamation": "Loaded!",
+      "loaded": "Loaded"
+    },
+
+    "save": {
+      "saveWithEllipsis": "Save...",
+      "save": "Save",
+      "savingWithEllipsis": "Saving...",
+      "saving": "Saving",
+      "savedWithExclamation": "Saved!",
+      "saved": "Saved"
+    },
+
+    "saveAs": {
+      "saveAsWithEllipsis": "Save As...",
+      "saveAs": "Save As"
+    },
+
+    "saveAsNew": {
+      "saveAsNewWithEllipsis": "Save As New...",
+      "saveAsNew": "Save As New"
+    },
+
+    "search": {
+      "searchWithEllipsis": "Search...",
+      "search": "Search",
+      "searchingWithEllipsis": "Searching...",
+      "searching": "Searching"
+    },
+
+    "update": {
+      "updateWithEllipsis": "Update...",
+      "update": "Update",
+      "updatingWithEllipsis": "Updating...",
+      "updating": "Updating",
+      "updatedWithExclamation": "Updated!",
+      "updated": "Updated"
+    },
+
+    "create": {
+      "createWithEllipsis": "Create...",
+      "create": "Create",
+      "creatingWithEllipsis": "Creating",
+      "creating": "Creating",
+      "createdWithExclamation": "Created!",
+      "created": "Created"
+    },
+
+    "reset": {
+      "resetWithEllipsis": "Reset...",
+      "reset": "Reset",
+      "resettingWithEllipsis": "Resetting...",
+      "resetting": "Resetting"
+    },
+
+    "pause": {
+      "pause": "Pause",
+      "pausingWithEllipsis": "Pausing...",
+      "pausing": "Pausing",
+      "paused": "Paused"
+    },
+
+    "download": {
+      "download": "Download",
+      "downloadingWithEllipsis": "Downloading...",
+      "downloading": "Downloading",
+      "downloadedWithExclamation": "Downloaded!",
+      "downloaded": "Downloaded"
+    },
+
+    "upload": {
+      "uploadWithEllipsis": "Upload...",
+      "upload": "Upload",
+      "uploadingWithEllipsis": "Uploading...",
+      "uploading": "Uploading",
+      "uploadedWithExclamation": "Uploaded!",
+      "uploaded": "Uploaded"
+    },
+
+    "remove": {
+      "removeWithEllipsis": "Remove...",
+      "remove": "Remove",
+      "removingWithEllipsis": "Removing...",
+      "removing": "Removing",
+      "removedWithExclamation": "Removed!",
+      "removed": "Removed"
+    },
+
+    "uninstall": {
+      "uninstallWithEllipsis": "Uninstall...",
+      "uninstall": "Uninstall",
+      "uninstallingWithEllipsis": "Uninstalling...",
+      "uninstalling": "Uninstalling",
+      "uninstalledWithExclamation": "Uninstalled!",
+      "uninstalled": "Uninstalled"
+    },
+
+    "resume": {
+      "resumeWithEllipsis": "Resume...",
+      "resume": "Resume",
+      "resumingWithEllipsis": "Resuming...",
+      "resuming": "Resuming"
+    },
+
+    "start": {
+      "startWithEllipsis": "Start...",
+      "start": "Start",
+      "startingWithEllipsis": "Starting...",
+      "starting": "Starting",
+      "started": "Started"
+    },
+
+    "stop": {
+      "stopWithEllipsis": "Stop...",
+      "stop": "Stop",
+      "stoppingWithEllipsis": "Stopping...",
+      "stopping": "Stopping",
+      "stoppedWithExclamation": "Stopped!",
+      "stopped": "Stopped"
+    },
+
+    "import": {
+      "importWithEllipsis": "Import...",
+      "import": "Import",
+      "importingWithEllipsis": "Importing...",
+      "importing": "Importing",
+      "importedWithExclamation": "Imported!",
+      "imported": "Imported"
+    },
+
+    "letsGo": {
+      "letsGo": "Let's Go",
+      "letsGoWithEllipsis": "Let's Go...",
+      "letsGoWithExclamation": "Let's Go!"
+    },
+
+    "run": {
+      "runWithEllipsis": "Run...",
+      "run": "Run",
+      "runningWithEllipsis": "Running...",
+      "running": "Running"
+    },
+
+    "configure": {
+      "configureWithEllipsis": "Configure...",
+      "configure": "Configure",
+      "configuringWithEllipsis": "Configuring...",
+      "configured": "Configured"
+    }
+  }
 }

--- a/en/shared.json
+++ b/en/shared.json
@@ -33,258 +33,257 @@
   "artifacts": {
     "fetchError": "Failed to fetch artifacts"
   },
+
   "incompatible": "Incompatible",
   "compatible": "Compatible",
   "public": "Public",
   "private": "Private",
+  "yes": "Yes",
+  "no": "No",
+  "go": "Go",
 
-  "commonActionStates": {
-    "yes": "Yes",
-    "no": "No",
-    "go": "Go",
-    "proceedWithEllipsis": "Proceed...",
-    "proceed": "Proceed",
-    "inProgress": "In progress...",
-    "failed": "Failed",
-    "pending": "Pending",
-    "doneWithExclamation": "Done!",
-    "done": "Done",
+  "proceedWithEllipsis": "Proceed...",
+  "proceed": "Proceed",
+  "inProgress": "In progress...",
+  "failed": "Failed",
+  "pending": "Pending",
+  "doneWithExclamation": "Done!",
+  "done": "Done",
 
-    "complete": {
-      "completeWithEllipsis": "Complete...",
-      "complete": "Complete",
-      "completingWithEllipsis": "Completing...",
-      "completing": "Completing",
-      "completedWithExclamation": "Completed!",
-      "completed": "Completed"
-    },
+  "complete": {
+    "completeWithEllipsis": "Complete...",
+    "complete": "Complete",
+    "completingWithEllipsis": "Completing...",
+    "completing": "Completing",
+    "completedWithExclamation": "Completed!",
+    "completed": "Completed"
+  },
 
-    "cancel": {
-      "cancelWithEllipsis": "Cancel...",
-      "cancel": "Cancel",
-      "cancelingWithEllipsis": "Canceling...",
-      "canceling": "Canceling",
-      "canceled": "Canceled"
-    },
+  "cancel": {
+    "cancelWithEllipsis": "Cancel...",
+    "cancel": "Cancel",
+    "cancelingWithEllipsis": "Canceling...",
+    "canceling": "Canceling",
+    "canceled": "Canceled"
+  },
 
-    "back": {
-      "backWithEllipsis": "Back...",
-      "back": "Back"
-    },
+  "back": {
+    "backWithEllipsis": "Back...",
+    "back": "Back"
+  },
 
-    "close": {
-      "closeWithEllipsis": "Close...",
-      "close": "Close",
-      "closingWithEllipsis": "Closing...",
-      "closing": "Closing",
-      "closedWithExclamation": "Closed!",
-      "closed": "Closed"
-    },
+  "close": {
+    "closeWithEllipsis": "Close...",
+    "close": "Close",
+    "closingWithEllipsis": "Closing...",
+    "closing": "Closing",
+    "closedWithExclamation": "Closed!",
+    "closed": "Closed"
+  },
 
-    "delete": {
-      "deleteWithEllipsis": "Delete...",
-      "delete": "Delete",
-      "deletingWithEllipsis": "Deleting...",
-      "deleting": "Deleting",
-      "deletedWithExclamation": "Deleted!",
-      "deleted": "Deleted"
-    },
+  "delete": {
+    "deleteWithEllipsis": "Delete...",
+    "delete": "Delete",
+    "deletingWithEllipsis": "Deleting...",
+    "deleting": "Deleting",
+    "deletedWithExclamation": "Deleted!",
+    "deleted": "Deleted"
+  },
 
-    "retry": {
-      "retryWithEllipsis": "Retry...",
-      "retry": "Retry",
-      "retryingWithEllipsis": "Retrying...",
-      "retrying": "Retrying"
-    },
+  "retry": {
+    "retryWithEllipsis": "Retry...",
+    "retry": "Retry",
+    "retryingWithEllipsis": "Retrying...",
+    "retrying": "Retrying"
+  },
 
-    "refresh": {
-      "refreshWithEllipsis": "Refresh...",
-      "refresh": "Refresh",
-      "refreshingWithEllipsis": "Refreshing...",
-      "refreshing": "Refreshing",
-      "refreshedWithExclamation": "Refreshed!",
-      "refreshed": "Refreshed"
-    },
+  "refresh": {
+    "refreshWithEllipsis": "Refresh...",
+    "refresh": "Refresh",
+    "refreshingWithEllipsis": "Refreshing...",
+    "refreshing": "Refreshing",
+    "refreshedWithExclamation": "Refreshed!",
+    "refreshed": "Refreshed"
+  },
 
-    "confirm": {
-      "confirm": "Confirm",
-      "confirmingWithEllipsis": "Confirming...",
-      "confirming": "Confirming",
-      "confirmedWithExclamation": "Confirmed!",
-      "confirmed": "Confirmed"
-    },
+  "confirm": {
+    "confirm": "Confirm",
+    "confirmingWithEllipsis": "Confirming...",
+    "confirming": "Confirming",
+    "confirmedWithExclamation": "Confirmed!",
+    "confirmed": "Confirmed"
+  },
 
-    "copy": {
-      "copyWithEllipsis": "Copy...",
-      "copy": "Copy",
-      "copyingWithEllipsis": "Copying...",
-      "copying": "Copying",
-      "copiedWithExclamation": "Copied!",
-      "copied": "Copied"
-    },
+  "copy": {
+    "copyWithEllipsis": "Copy...",
+    "copy": "Copy",
+    "copyingWithEllipsis": "Copying...",
+    "copying": "Copying",
+    "copiedWithExclamation": "Copied!",
+    "copied": "Copied"
+  },
 
-    "edit": {
-      "editWithEllipsis": "Edit...",
-      "edit": "Edit",
-      "editingWithEllipsis": "Editing...",
-      "editing": "Editing",
-      "editedWithExclamation": "Edited!",
-      "edited": "Edited"
-    },
+  "edit": {
+    "editWithEllipsis": "Edit...",
+    "edit": "Edit",
+    "editingWithEllipsis": "Editing...",
+    "editing": "Editing",
+    "editedWithExclamation": "Edited!",
+    "edited": "Edited"
+  },
 
-    "load": {
-      "loadWithEllipsis": "Load...",
-      "load": "Load",
-      "loadingWithEllipsis": "Loading...",
-      "loading": "Loading",
-      "loadedWithExclamation": "Loaded!",
-      "loaded": "Loaded"
-    },
+  "load": {
+    "loadWithEllipsis": "Load...",
+    "load": "Load",
+    "loadingWithEllipsis": "Loading...",
+    "loading": "Loading",
+    "loadedWithExclamation": "Loaded!",
+    "loaded": "Loaded"
+  },
 
-    "save": {
-      "saveWithEllipsis": "Save...",
-      "save": "Save",
-      "savingWithEllipsis": "Saving...",
-      "saving": "Saving",
-      "savedWithExclamation": "Saved!",
-      "saved": "Saved"
-    },
+  "save": {
+    "saveWithEllipsis": "Save...",
+    "save": "Save",
+    "savingWithEllipsis": "Saving...",
+    "saving": "Saving",
+    "savedWithExclamation": "Saved!",
+    "saved": "Saved"
+  },
 
-    "saveAs": {
-      "saveAsWithEllipsis": "Save As...",
-      "saveAs": "Save As"
-    },
+  "saveAs": {
+    "saveAsWithEllipsis": "Save As...",
+    "saveAs": "Save As"
+  },
 
-    "saveAsNew": {
-      "saveAsNewWithEllipsis": "Save As New...",
-      "saveAsNew": "Save As New"
-    },
+  "saveAsNew": {
+    "saveAsNewWithEllipsis": "Save As New...",
+    "saveAsNew": "Save As New"
+  },
 
-    "search": {
-      "searchWithEllipsis": "Search...",
-      "search": "Search",
-      "searchingWithEllipsis": "Searching...",
-      "searching": "Searching"
-    },
+  "search": {
+    "searchWithEllipsis": "Search...",
+    "search": "Search",
+    "searchingWithEllipsis": "Searching...",
+    "searching": "Searching"
+  },
 
-    "update": {
-      "updateWithEllipsis": "Update...",
-      "update": "Update",
-      "updatingWithEllipsis": "Updating...",
-      "updating": "Updating",
-      "updatedWithExclamation": "Updated!",
-      "updated": "Updated"
-    },
+  "update": {
+    "updateWithEllipsis": "Update...",
+    "update": "Update",
+    "updatingWithEllipsis": "Updating...",
+    "updating": "Updating",
+    "updatedWithExclamation": "Updated!",
+    "updated": "Updated"
+  },
 
-    "create": {
-      "createWithEllipsis": "Create...",
-      "create": "Create",
-      "creatingWithEllipsis": "Creating",
-      "creating": "Creating",
-      "createdWithExclamation": "Created!",
-      "created": "Created"
-    },
+  "create": {
+    "createWithEllipsis": "Create...",
+    "create": "Create",
+    "creatingWithEllipsis": "Creating",
+    "creating": "Creating",
+    "createdWithExclamation": "Created!",
+    "created": "Created"
+  },
 
-    "reset": {
-      "resetWithEllipsis": "Reset...",
-      "reset": "Reset",
-      "resettingWithEllipsis": "Resetting...",
-      "resetting": "Resetting"
-    },
+  "reset": {
+    "resetWithEllipsis": "Reset...",
+    "reset": "Reset",
+    "resettingWithEllipsis": "Resetting...",
+    "resetting": "Resetting"
+  },
 
-    "pause": {
-      "pause": "Pause",
-      "pausingWithEllipsis": "Pausing...",
-      "pausing": "Pausing",
-      "paused": "Paused"
-    },
+  "pause": {
+    "pause": "Pause",
+    "pausingWithEllipsis": "Pausing...",
+    "pausing": "Pausing",
+    "paused": "Paused"
+  },
 
-    "download": {
-      "download": "Download",
-      "downloadingWithEllipsis": "Downloading...",
-      "downloading": "Downloading",
-      "downloadedWithExclamation": "Downloaded!",
-      "downloaded": "Downloaded"
-    },
+  "download": {
+    "download": "Download",
+    "downloadingWithEllipsis": "Downloading...",
+    "downloading": "Downloading",
+    "downloadedWithExclamation": "Downloaded!",
+    "downloaded": "Downloaded"
+  },
 
-    "upload": {
-      "uploadWithEllipsis": "Upload...",
-      "upload": "Upload",
-      "uploadingWithEllipsis": "Uploading...",
-      "uploading": "Uploading",
-      "uploadedWithExclamation": "Uploaded!",
-      "uploaded": "Uploaded"
-    },
+  "upload": {
+    "uploadWithEllipsis": "Upload...",
+    "upload": "Upload",
+    "uploadingWithEllipsis": "Uploading...",
+    "uploading": "Uploading",
+    "uploadedWithExclamation": "Uploaded!",
+    "uploaded": "Uploaded"
+  },
 
-    "remove": {
-      "removeWithEllipsis": "Remove...",
-      "remove": "Remove",
-      "removingWithEllipsis": "Removing...",
-      "removing": "Removing",
-      "removedWithExclamation": "Removed!",
-      "removed": "Removed"
-    },
+  "remove": {
+    "removeWithEllipsis": "Remove...",
+    "remove": "Remove",
+    "removingWithEllipsis": "Removing...",
+    "removing": "Removing",
+    "removedWithExclamation": "Removed!",
+    "removed": "Removed"
+  },
 
-    "uninstall": {
-      "uninstallWithEllipsis": "Uninstall...",
-      "uninstall": "Uninstall",
-      "uninstallingWithEllipsis": "Uninstalling...",
-      "uninstalling": "Uninstalling",
-      "uninstalledWithExclamation": "Uninstalled!",
-      "uninstalled": "Uninstalled"
-    },
+  "uninstall": {
+    "uninstallWithEllipsis": "Uninstall...",
+    "uninstall": "Uninstall",
+    "uninstallingWithEllipsis": "Uninstalling...",
+    "uninstalling": "Uninstalling",
+    "uninstalledWithExclamation": "Uninstalled!",
+    "uninstalled": "Uninstalled"
+  },
 
-    "resume": {
-      "resumeWithEllipsis": "Resume...",
-      "resume": "Resume",
-      "resumingWithEllipsis": "Resuming...",
-      "resuming": "Resuming"
-    },
+  "resume": {
+    "resumeWithEllipsis": "Resume...",
+    "resume": "Resume",
+    "resumingWithEllipsis": "Resuming...",
+    "resuming": "Resuming"
+  },
 
-    "start": {
-      "startWithEllipsis": "Start...",
-      "start": "Start",
-      "startingWithEllipsis": "Starting...",
-      "starting": "Starting",
-      "started": "Started"
-    },
+  "start": {
+    "startWithEllipsis": "Start...",
+    "start": "Start",
+    "startingWithEllipsis": "Starting...",
+    "starting": "Starting",
+    "started": "Started"
+  },
 
-    "stop": {
-      "stopWithEllipsis": "Stop...",
-      "stop": "Stop",
-      "stoppingWithEllipsis": "Stopping...",
-      "stopping": "Stopping",
-      "stoppedWithExclamation": "Stopped!",
-      "stopped": "Stopped"
-    },
+  "stop": {
+    "stopWithEllipsis": "Stop...",
+    "stop": "Stop",
+    "stoppingWithEllipsis": "Stopping...",
+    "stopping": "Stopping",
+    "stoppedWithExclamation": "Stopped!",
+    "stopped": "Stopped"
+  },
 
-    "import": {
-      "importWithEllipsis": "Import...",
-      "import": "Import",
-      "importingWithEllipsis": "Importing...",
-      "importing": "Importing",
-      "importedWithExclamation": "Imported!",
-      "imported": "Imported"
-    },
+  "import": {
+    "importWithEllipsis": "Import...",
+    "import": "Import",
+    "importingWithEllipsis": "Importing...",
+    "importing": "Importing",
+    "importedWithExclamation": "Imported!",
+    "imported": "Imported"
+  },
 
-    "letsGo": {
-      "letsGo": "Let's Go",
-      "letsGoWithEllipsis": "Let's Go...",
-      "letsGoWithExclamation": "Let's Go!"
-    },
+  "letsGo": {
+    "letsGo": "Let's Go",
+    "letsGoWithEllipsis": "Let's Go...",
+    "letsGoWithExclamation": "Let's Go!"
+  },
 
-    "run": {
-      "runWithEllipsis": "Run...",
-      "run": "Run",
-      "runningWithEllipsis": "Running...",
-      "running": "Running"
-    },
+  "run": {
+    "runWithEllipsis": "Run...",
+    "run": "Run",
+    "runningWithEllipsis": "Running...",
+    "running": "Running"
+  },
 
-    "configure": {
-      "configureWithEllipsis": "Configure...",
-      "configure": "Configure",
-      "configuringWithEllipsis": "Configuring...",
-      "configured": "Configured"
-    }
+  "configure": {
+    "configureWithEllipsis": "Configure...",
+    "configure": "Configure",
+    "configuringWithEllipsis": "Configuring...",
+    "configured": "Configured"
   }
 }


### PR DESCRIPTION
I'm adding to the shared localization file a handful of common action states which are duplicated frequently in existing localization definitions. The goal will be to use these moving forward when needing a generic action state localization, such as "Cancel" or "Done"