### PR TITLE
Add missing strings with Swedish translations

### DIFF
--- a/sv/chat.json
+++ b/sv/chat.json
@@ -89,6 +89,11 @@
 	"actions/createFolderAtRoot": "Ny mapp...",
 	"actions/createFolderAtRoot/error": "Misslyckades med att skapa mapp vid roten",
 	"actions/createChat/error": "Misslyckades med att skapa chatt",
+  "actions/openInFolder/mac": "Visa i Finder",
+  "actions/openInFolder/pc": "Öppna i Utforskaren",
+
+	"actions/createFolder/error": "Misslyckades med att skapa chatt",
+	"actions/deleteChat/errorTitle": "Misslyckades med att radera chatt",
 
 	"userFile/fileSizeLimit": "Filstorleksgräns är ",
 	"userFile/noImageSupport": "Modellen stöder inte bildinmatning",
@@ -98,7 +103,12 @@
 	"userFile/unsupportedFileType": "Ej stödd filtyp - endast bilder, PDF-filer och .txt-filer stöds.",
 	"userFile/maxFilesPerMessage": "Maximalt antal filer per meddelande nått. Kan inte lägga till fler än {{files}} filer.",
 	"userFile/maxFileSizePerMessage": "Maximal filstorlek per meddelande nådd. Kan inte lägga till filer större än {{size}}.",
+	"userFile/maxFileSizePerConversation": "Maximal filstorlek per konversation är nådd. Kan inte lägga till filer större än {{size}}. ",
+	"userFile/failedToUploadError/title": "Misslyckades med att ladda upp fil",
+	"userFile/failedToAddFile/title": "Misslyckades med att lägga till fil i chatten",
 	"errorTitle": "Fel",
+	"userFile/chatTerminalDocumentsCount_one": "{{count}} dokument i chatten",
+	"userFile/chatTerminalDocumentsCount_other": "{{count}} dokument i chatten",
 
 	"prediction/busyModel/title": "Modellen är upptagen",
 	"prediction/busyModel/message": "Vänligen vänta tills modellen är klar och försök igen",
@@ -118,10 +128,32 @@
 	"style/viewMode/plaintext": "Ren text",
 	"style/viewMode/monospace": "Monospace",
 
+	"speculativeDecodingVisualization/toggle": "Visualisera accepterade utkasttoken",
+	"speculativeDecodingVisualization/fromDraftModel_one": "Accepterad utkasttoken",
+	"speculativeDecodingVisualization/fromDraftModel_other": "Accepterade utkasttoken",
+	"speculativeDecodingVisualization/cannotChangeViewMode": "Val av visningsläge är inaktiverat när utkasttoken visualiseras.",
+
 	"style/fontSize/label": "Teckenstorlek",
 	"style/fontSize/medium": "Standard",
 	"style/fontSize/large": "Stor",
 	"style/fontSize/small": "Liten",
+
+	"style/debugBlocks/label": "Visa felsökningsinformationsblock",
+	
+	"style/thinkingUI/label": "Expandera resoneringsblock som standard",
+	"style/chatFullWidth/label": "Expandera chattcontainern till fönstrets bredd",
+	
+	"style/chatUtilityMenusShowLabel/label": "Visa etiketter för chattverktygsmenyer",
+	
+	"messageBlocks": {
+		"expandBlockTooltip": "Expandera innehåll",
+		"collapseBlockTooltip": "Komprimera innehåll",
+		"debug": {
+			"label": "FELSÖKNINGSINFO",
+			"collapseTooltip": "Komprimera felsökningsinformationsblock",
+			"expandTooltip": "Expandera felsökningsinformationsblock"
+		}
+	},
 
 	"topBarActions/duplicateChat": "Duplicera chatt",
 	"topBarActions/clearChat": "Rensa alla meddelanden",
@@ -131,5 +163,80 @@
 
 	"noModels.indexing": "Indexerar modellfiler... (detta kan ta en stund)",
 	"noModels.downloading": "Laddar ner din första LLM...",
-	"noModels": "Inga LLM:er ännu! Ladda ner en för att komma igång!"
+	"noModels": "Inga LLM:er ännu! Ladda ner en för att komma igång!",
+
+	"plugins": {
+		"pluginTrigger": {
+			"noPlugins": "Plugin",
+			"multiplePlugins": "{{dynamicValue}} plugins"
+		},
+		"pluginSelect": {
+			"title": "Plugins",
+			"dropdown": {
+				"configure": "Konfigurera",
+				"disable": "Inaktivera",
+				"fork": "Förgrena",
+				"uninstall": "Avinstallera"
+			},
+			"actionButtons": {
+				"create": "Skapa",
+				"import": "Importera",
+				"discover": "Utforska"
+			},
+			"recentlyCreated": {
+				"title": "Nyligen skapade plugins",
+				"placeholder": "Plugins du skapar kommer visas här"
+			},
+			"startRunningDevelopmentPlugin/error": "Misslyckades med att starta plugin i utvecklingsläge",
+			"stopRunningDevelopmentPlugin/error": "Misslyckades med att stoppa plugin i utvecklingsläge"
+		},
+		"pluginConfiguration": {
+			"title": "Pluginkonfiguration",
+			"selectAPlugin": "Välj en plugin för att redigera dess konfigurationer",
+			"preprocessorAndGenerator": "Denna plugin innehåller en anpassad förbehandlare och generator",
+			"generatorOnly": "Denna plugin innehåller en anpassad generator",
+			"preprocessorOnly": "Denna plugin innehåller en anpassad förbehandlare"
+		},
+		"instructions": {
+			"runTheFollowing": "För att köra din plugin, öppna en terminal och ange",
+			"pushTo": "Dela din plugin med andra genom att publicera till Hub (valfritt)",
+			"createdSuccessfully": "Plugin skapades framgångsrikt",
+			"creatingPlugin": "Skapar plugin...",
+			"projectFilesTitle": "Projektfiler",
+			"buttons": {
+				"documentation": "Dokumentation",
+				"dismiss": "Avvisa",
+				"publish": "Publicera",
+				"openInZed": "Öppna i Zed",
+				"openInVscode": "Öppna i VS Code",
+				"revealInFinder": "Visa i Finder",
+				"openInFileExplorer": "Öppna i Utforskaren"
+			}
+		},
+		"localFork": {
+			"error": "Misslyckades med att skapa en lokal utvecklingskopia av pluginen."
+		},
+		"restartErrorPlugin/error": "Misslyckades med att starta om pluginen"
+	},
+
+	"genInfo": {
+		"tokensPerSecond": "{{tokensPerSecond}} token/sek",
+		"predictedTokensCount": "{{predictedTokensCount}} token",
+		"timeToFirstTokenSec": "{{timeToFirstTokenSec}}s till första token",
+		"stopReason": "Stopporsak: {{stopReason}}",
+		"stopReason.userStopped": "Användaren avbröt",
+		"stopReason.modelUnloaded": "Modellen avlastades",
+		"stopReason.failed": "Generering misslyckades",
+		"stopReason.eosFound": "EOS-token hittades",
+		"stopReason.stopStringFound": "Stoppsträng hittades",
+		"stopReason.toolCalls": "Verktygsanrop",
+		"stopReason.maxPredictedTokensReached": "Maximalt antal förutsedda token uppnåddes",
+		"stopReason.contextLengthReached": "Kontextlängdsgräns uppnåddes",
+		"speculativeDecodedBy": "Utkastmodell: {{decodedBy}}",
+		"speculativeDecodingStats": "Accepterade {{accepted}}/{{total}} utkasttoken ({{percentage}}%)"
+	},
+
+	"tabs": {
+		"systemPromptEditorTab.headerLabel": "Redigerar systemprompt"
+	}
 }

--- a/sv/config.json
+++ b/sv/config.json
@@ -21,21 +21,36 @@
 	"loadParameters/title": "Ladda parametrar",
 	"loadParameters/description": "Inställningar för att kontrollera hur modellen initieras och laddas i minnet.",
 	"loadParameters/reload": "Ladda om för att tillämpa ändringar",
+	"loadParameters/reload/error": "Misslyckades med att ladda om modellen",
 	"discardChanges": "Ångra ändringar",
 	"loadModelToSeeOptions": "Ladda en modell för att se alternativ",
+	"schematicsError.title": "Konfigurationsschemat innehåller fel i följande fält:",
+	"manifestSections": {
+		"structuredOutput/title": "Strukturerad utdata",
+		"speculativeDecoding/title": "Spekulativ avkodning",
+		"sampling/title": "Sampling",
+		"settings/title": "Inställningar",
+		"toolUse/title": "Verktygsanvändning",
+		"promptTemplate/title": "Promptmall",
+		"customFields/title": "Anpassade fält"
+  },
+
 	"llm.prediction.systemPrompt/title": "Systemprompt",
 	"llm.prediction.systemPrompt/description": "Använd detta fält för att ge bakgrundsinstruktioner till modellen, såsom en uppsättning regler, begränsningar eller allmänna krav.",
 	"llm.prediction.systemPrompt/subTitle": "Riktlinjer för AI:n",
+	"llm.prediction.systemPrompt/openEditor": "Redigerare",
+	"llm.prediction.systemPrompt/closeEditor": "Stäng redigerare",
+	"llm.prediction.systemPrompt/openedEditor": "Öppnad i redigerare...",
 	"llm.prediction.temperature/title": "Temperatur",
 	"llm.prediction.temperature/subTitle": "Hur mycket slumpmässighet som ska introduceras. 0 ger samma resultat varje gång, medan högre värden ökar kreativiteten och variationen",
-	"llm.prediction.temperature/info": "Från llama.cpp hjälpdokument: \"Standardvärdet är <{{dynamicValue}}>, vilket ger en balans mellan slumpmässighet och determinism. I extrema fall kommer en temperatur på 0 alltid att välja den mest sannolika nästa token, vilket leder till identiska utdata vid varje körning\"",
+	"llm.prediction.temperature/info": "Från llama.cpp hjälpdokumentation: \"Standardvärdet är <{{dynamicValue}}>, vilket ger en balans mellan slumpmässighet och determinism. I extrema fall kommer en temperatur på 0 alltid att välja den mest sannolika nästa token, vilket leder till identiska utdata vid varje körning\"",
 	"llm.prediction.llama.sampling/title": "Sampling",
 	"llm.prediction.topKSampling/title": "Top K Sampling",
 	"llm.prediction.topKSampling/subTitle": "Begränsar nästa token till en av de top-k mest sannolika token. Fungerar liknande som temperatur",
-	"llm.prediction.topKSampling/info": "Från llama.cpp hjälpdokument:\n\nTop-k sampling är en textgenereringsmetod som väljer nästa token endast från de top k mest sannolika token som modellen förutspår.\n\nDet hjälper till att minska risken för att generera låg sannolikhet eller nonsens token, men det kan också begränsa mångfalden i utdata.\n\nEtt högre värde för top-k (t.ex. 100) kommer att överväga fler token och leda till mer varierad text, medan ett lägre värde (t.ex. 10) kommer att fokusera på de mest sannolika token och generera mer konservativ text.\n\n• Standardvärdet är <{{dynamicValue}}>",
+	"llm.prediction.topKSampling/info": "Från llama.cpp hjälpdokumentation:\n\nTop-k sampling är en textgenereringsmetod som väljer nästa tecken endast från de k mest sannolika som modellen förutspår.\n\nDet hjälper till att minska risken för att generera låg-sannolikhet eller nonsens-tecken, men kan också begränsa mångfalden i utdata.\n\nEtt högre värde för top-k (t.ex. 100) kommer att överväga fler tecken och leda till mer varierad text, medan ett lägre värde (t.ex. 10) fokuserar på de mest sannolika och genererar mer konservativ text.\n\n• Standardvärdet är <{{dynamicValue}}>",
 	"llm.prediction.llama.cpuThreads/title": "CPU-trådar",
-	"llm.prediction.llama.cpuThreads/subTitle": "Antal CPU-trådar att använda under inferens",
-	"llm.prediction.llama.cpuThreads/info": "Antalet trådar att använda under beräkning. Att öka antalet trådar korrelerar inte alltid med bättre prestanda. Standardvärdet är <{{dynamicValue}}>.",
+	"llm.prediction.llama.cpuThreads/subTitle": "Antal CPU-trådar att använda vid inferens",
+	"llm.prediction.llama.cpuThreads/info": "Antalet trådar som används vid beräkning. Att öka antalet trådar ger inte alltid bättre prestanda. Standardvärdet är <{{dynamicValue}}>.",
 	"llm.prediction.maxPredictedTokens/title": "Begränsa svarslängd",
 	"llm.prediction.maxPredictedTokens/subTitle": "Valfritt begränsa längden på AI:s svar",
 	"llm.prediction.maxPredictedTokens/info": "Kontrollera maxlängden på chatbotens svar. Slå på för att ställa in en gräns för maxlängden på ett svar, eller slå av för att låta chatboten bestämma när den ska sluta.",
@@ -61,6 +76,15 @@
 	"llm.prediction.llama.presencePenalty/title": "Närvarobegränsning",
 	"llm.prediction.llama.tailFreeSampling/title": "Tail-Free Sampling",
 	"llm.prediction.llama.locallyTypicalSampling/title": "Lokalt typisk sampling",
+	"llm.prediction.llama.xtcProbability/title": "XTC-sannolikhet",
+	"llm.prediction.llama.xtcProbability/subTitle": "XTC (Exclude Top Choices) sampling aktiveras endast med denna sannolikhet per genererat tecken. XTC sampling kan öka kreativiteten och minska klichéer",
+	"llm.prediction.llama.xtcProbability/info": "XTC (Exclude Top Choices) sampling aktiveras endast med denna sannolikhet per genererat tecken. XTC sampling ökar vanligtvis kreativiteten och minskar klichéer",
+	"llm.prediction.llama.xtcThreshold/title": "XTC-tröskel",
+	"llm.prediction.llama.xtcThreshold/subTitle": "XTC (Exclude Top Choices) tröskel. Med en chans på `xtc-probability`, sök efter tecken med sannolikheter mellan `xtc-threshold` och 0.5, och ta bort alla utom det minst sannolika",
+	"llm.prediction.llama.xtcThreshold/info": "XTC (Exclude Top Choices) tröskel. Med en chans på `xtc-probability`, sök efter tecken med sannolikheter mellan `xtc-threshold` och 0.5, och ta bort alla utom det minst sannolika",
+	"llm.prediction.mlx.topKSampling/title": "Top K Sampling",
+	"llm.prediction.mlx.topKSampling/subTitle": "Begränsar nästa tecken till en av de k mest sannolika. Fungerar liknande som temperatur",
+	"llm.prediction.mlx.topKSampling/info": "Begränsar nästa tecken till en av de k mest sannolika. Fungerar liknande som temperatur",
 	"llm.prediction.onnx.topKSampling/title": "Top K Sampling",
 	"llm.prediction.onnx.topKSampling/subTitle": "Begränsar nästa token till en av de top-k mest sannolika token. Fungerar liknande som temperatur",
 	"llm.prediction.onnx.topKSampling/info": "Från ONNX-dokumentation:\n\nAntal högsta sannolikhetsvokabulärtoken att behålla för top-k-filtrering\n\n• Detta filter är avstängt som standard",
@@ -85,20 +109,20 @@
 	"llm.load.seed/info": "Slumpmässig Seed: Ställer in seed för slumptalsgenerering för att säkerställa reproducerbara resultat",
 	
 	"llm.load.llama.evalBatchSize/title": "Utvärderingsbatchstorlek",
-	"llm.load.llama.evalBatchSize/subTitle": "Antal input-token att bearbeta åt gången. Att öka detta ökar prestandan på bekostnad av minnesanvändning",
-	"llm.load.llama.evalBatchSize/info": "Ställer in antalet exempel som bearbetas tillsammans i en batch under utvärdering, vilket påverkar hastighet och minnesanvändning",
-	"llm.load.llama.ropeFrequencyBase/title": "RoPE Basfrekvens",
-	"llm.load.llama.ropeFrequencyBase/subTitle": "Anpassad basfrekvens för roterande positionsinbäddningar (RoPE). Att öka detta kan möjliggöra bättre prestanda vid höga kontextlängder",
-	"llm.load.llama.ropeFrequencyBase/info": "[Avancerat] Justerar basfrekvensen för roterande positionskodning, vilket påverkar hur positionsinformation inbäddas",
-	"llm.load.llama.ropeFrequencyScale/title": "RoPE Frekvensskala",
-	"llm.load.llama.ropeFrequencyScale/subTitle": "Kontextlängden skalas med denna faktor för att utöka effektiv kontext med hjälp av RoPE",
-	"llm.load.llama.ropeFrequencyScale/info": "[Avancerat] Modifierar skalningen av frekvensen för roterande positionskodning för att kontrollera positionskodningens granularitet",
-	"llm.load.llama.acceleration.offloadRatio/title": "GPU-avlastning",
+	"llm.load.llama.evalBatchSize/subTitle": "Antal inmatningstokens att bearbeta åt gången. Att öka detta ökar prestandan men kräver mer minne",
+	"llm.load.llama.evalBatchSize/info": "Anger antalet exempel som bearbetas tillsammans i en batch under utvärdering, vilket påverkar hastighet och minnesanvändning",
+	"llm.load.llama.ropeFrequencyBase/title": "RoPE-frekvensbas",
+	"llm.load.llama.ropeFrequencyBase/subTitle": "Anpassad basfrekvens för roterande positionsinbäddningar (RoPE). Att öka detta kan ge bättre prestanda vid höga kontextlängder",
+	"llm.load.llama.ropeFrequencyBase/info": "[Avancerat] Justerar basfrekvensen för Rotary Positional Encoding, vilket påverkar hur positionsinformation bäddas in",
+	"llm.load.llama.ropeFrequencyScale/title": "RoPE-frekvensskalning",
+	"llm.load.llama.ropeFrequencyScale/subTitle": "Kontextlängden skalas med denna faktor för att förlänga effektiv kontext med RoPE",
+	"llm.load.llama.ropeFrequencyScale/info": "[Avancerat] Ändrar skalningen av frekvensen för Rotary Positional Encoding för att styra granulariteten i positionsinbäddningen",
+	"llm.load.llama.acceleration.offloadRatio/title": "GPU-offload",
 	"llm.load.llama.acceleration.offloadRatio/subTitle": "Antal diskreta modellager att beräkna på GPU för GPU-acceleration",
 	"llm.load.llama.acceleration.offloadRatio/info": "Ställ in antalet lager som ska avlastas till GPU:n.",
 	"llm.load.llama.flashAttention/title": "Flash Attention",
-	"llm.load.llama.flashAttention/subTitle": "Minskar minnesanvändning och genereringstid på vissa modeller",
-	"llm.load.llama.flashAttention/info": "Accelererar uppmärksamhetsmekanismer för snabbare och mer effektiv bearbetning",
+	"llm.load.llama.flashAttention/subTitle": "Minskar minnesanvändning och genereringstid för vissa modeller",
+	"llm.load.llama.flashAttention/info": "Snabbar upp attention-mekanismer för snabbare och effektivare bearbetning",
 	"llm.load.numExperts/title": "Antal experter",
 	"llm.load.numExperts/subTitle": "Antal experter att använda i modellen",
 	"llm.load.numExperts/info": "Antalet experter att använda i modellen",
@@ -108,107 +132,189 @@
 	"llm.load.llama.useFp16ForKVCache/title": "Använd FP16 för KV-cache",
 	"llm.load.llama.useFp16ForKVCache/info": "Minskar minnesanvändningen genom att lagra cache i halvprecision (FP16)",
 	"llm.load.llama.tryMmap/title": "Försök med mmap()",
-	"llm.load.llama.tryMmap/subTitle": "Förbättrar laddningstiden för modellen. Att inaktivera detta kan förbättra prestandan när modellen är större än tillgängligt system-RAM",
-	"llm.load.llama.tryMmap/info": "Ladda modellfiler direkt från disk till minne",
+	"llm.load.llama.tryMmap/subTitle": "Förbättrar inläsningstiden för modellen. Att inaktivera detta kan förbättra prestandan när modellen är större än tillgängligt systemminne",
+	"llm.load.llama.tryMmap/info": "Läs in modellfiler direkt från disk till minne",
+	"llm.load.llama.cpuThreadPoolSize/title": "CPU-trådpoolstorlek",
+	"llm.load.llama.cpuThreadPoolSize/subTitle": "Antal CPU-trådar att tilldela trådpoolen som används för modellberäkning",
+	"llm.load.llama.cpuThreadPoolSize/info": "Antal CPU-trådar att tilldela trådpoolen som används för modellberäkning. Att öka antalet trådar ger inte alltid bättre prestanda. Standardvärdet är <{{dynamicValue}}>",
+	"llm.load.llama.kCacheQuantizationType/title": "K-cache-kvantiseringstyp",
+	"llm.load.llama.kCacheQuantizationType/subTitle": "Lägre värden minskar minnesanvändningen men kan försämra kvaliteten. Effekten varierar mycket mellan modeller.",
+	"llm.load.llama.vCacheQuantizationType/title": "V-cache-kvantiseringstyp",
+	"llm.load.llama.vCacheQuantizationType/subTitle": "Lägre värden minskar minnesanvändningen men kan försämra kvaliteten. Effekten varierar mycket mellan modeller.",
+	"llm.load.llama.vCacheQuantizationType/turnedOnWarning": "⚠️ Du måste inaktivera detta värde om Flash Attention inte är aktiverat",
+	"llm.load.llama.vCacheQuantizationType/disabledMessage": "Kan endast aktiveras när Flash Attention är aktiverat",
+	"llm.load.llama.vCacheQuantizationType/invalidF32MetalState": "⚠️ Du måste inaktivera Flash Attention när du använder F32",
+	"llm.load.mlx.kvCacheBits/title": "KV-cache-kvantisering",
+	"llm.load.mlx.kvCacheBits/subTitle": "Antal bitar som KV-cachen ska kvantiseras till",
+	"llm.load.mlx.kvCacheBits/info": "Antal bitar som KV-cachen ska kvantiseras till",
+	"llm.load.mlx.kvCacheBits/turnedOnWarning": "Inställningen för kontextlängd ignoreras när KV-cache-kvantisering används",
+	"llm.load.mlx.kvCacheGroupSize/title": "KV-cache-kvantisering: Gruppstorlek",
+	"llm.load.mlx.kvCacheGroupSize/subTitle": "Gruppstorlek vid kvantiseringsoperationen för KV-cachen. Högre gruppstorlek minskar minnesanvändningen men kan försämra kvaliteten",
+	"llm.load.mlx.kvCacheGroupSize/info": "Antal bitar som KV-cachen ska kvantiseras till",
+	"llm.load.mlx.kvCacheQuantizationStart/title": "KV-cache-kvantisering: Börja kvantisera när kontexten passerar denna längd",
+	"llm.load.mlx.kvCacheQuantizationStart/subTitle": "Kontextlängdströskel för att börja kvantisera KV-cachen",
+	"llm.load.mlx.kvCacheQuantizationStart/info": "Kontextlängdströskel för att börja kvantisera KV-cachen",
+	"llm.load.mlx.kvCacheQuantization/title": "KV-cache-kvantisering",
+	"llm.load.mlx.kvCacheQuantization/subTitle": "Kvantisera modellens KV-cache. Detta kan ge snabbare generering och lägre minnesanvändning,\npå bekostnad av modellens utdata-kvalitet.",
+	"llm.load.mlx.kvCacheQuantization/bits/title": "KV-cache-kvantiseringsbitar",
+	"llm.load.mlx.kvCacheQuantization/bits/tooltip": "Antal bitar att kvantisera KV-cachen till",
+	"llm.load.mlx.kvCacheQuantization/bits/bits": "Bitar",
+	"llm.load.mlx.kvCacheQuantization/groupSize/title": "Gruppstorleksstrategi",
+	"llm.load.mlx.kvCacheQuantization/groupSize/accuracy": "Noggrannhet",
+	"llm.load.mlx.kvCacheQuantization/groupSize/balanced": "Balanserad",
+	"llm.load.mlx.kvCacheQuantization/groupSize/speedy": "Snabb",
+	"llm.load.mlx.kvCacheQuantization/groupSize/tooltip": "Avancerat: Kvantiserad 'matmul group size'-konfiguration\n\n• Noggrannhet = gruppstorlek 32\n• Balanserad = gruppstorlek 64\n• Snabb = gruppstorlek 128\n",
+	"llm.load.mlx.kvCacheQuantization/quantizedStart/title": "Börja kvantisera när kontexten når denna längd",
+	"llm.load.mlx.kvCacheQuantization/quantizedStart/tooltip": "När kontexten når detta antal tokens,\nbörja kvantisera KV-cachen",
 
 	"embedding.load.contextLength/title": "Kontextlängd",
-	"embedding.load.contextLength/subTitle": "Det maximala antalet token som modellen kan hantera i en prompt. Se alternativen för kontextöverflöd under \"Prediktionsparametrar\" för fler sätt att hantera detta",
-	"embedding.load.contextLength/info": "Anger det maximala antalet token som modellen kan överväga samtidigt, vilket påverkar hur mycket kontext den behåller under bearbetning",
-	"embedding.load.llama.ropeFrequencyBase/title": "RoPE Basfrekvens",
-	"embedding.load.llama.ropeFrequencyBase/subTitle": "Anpassad basfrekvens för roterande positionsinbäddningar (RoPE). Att öka detta kan möjliggöra bättre prestanda vid höga kontextlängder",
-	"embedding.load.llama.ropeFrequencyBase/info": "[Avancerat] Justerar basfrekvensen för roterande positionskodning, vilket påverkar hur positionsinformation inbäddas",
+	"embedding.load.contextLength/subTitle": "Maximalt antal tokens modellen kan hantera i en prompt. Se alternativen för kontextöverskridande under \"Inferensparametrar\" för fler sätt att hantera detta",
+	"embedding.load.contextLength/info": "Anger det maximala antalet tokens modellen kan ta hänsyn till samtidigt, vilket påverkar hur mycket kontext den behåller under bearbetning",
+	"embedding.load.llama.ropeFrequencyBase/title": "RoPE-frekvensbas",
+	"embedding.load.llama.ropeFrequencyBase/subTitle": "Anpassad basfrekvens för roterande positionsinbäddningar (RoPE). Att öka detta kan ge bättre prestanda vid höga kontextlängder",
+	"embedding.load.llama.ropeFrequencyBase/info": "[Avancerat] Justerar basfrekvensen för Rotary Positional Encoding, vilket påverkar hur positionsinformation bäddas in",
 	"embedding.load.llama.evalBatchSize/title": "Utvärderingsbatchstorlek",
-	"embedding.load.llama.evalBatchSize/subTitle": "Antal input-token att bearbeta åt gången. Att öka detta ökar prestandan på bekostnad av minnesanvändning",
-	"embedding.load.llama.evalBatchSize/info": "Ställer in antalet token som bearbetas tillsammans i en batch under utvärdering",
-	"embedding.load.llama.ropeFrequencyScale/title": "RoPE Frekvensskala",
-	"embedding.load.llama.ropeFrequencyScale/subTitle": "Kontextlängden skalas med denna faktor för att utöka effektiv kontext med hjälp av RoPE",
-	"embedding.load.llama.ropeFrequencyScale/info": "[Avancerat] Modifierar skalningen av frekvensen för roterande positionskodning för att kontrollera positionskodningens granularitet",
-	"embedding.load.llama.acceleration.offloadRatio/title": "GPU-avlastning",
+	"embedding.load.llama.evalBatchSize/subTitle": "Antal inmatningstokens att bearbeta åt gången. Att öka detta ökar prestandan men kräver mer minne",
+	"embedding.load.llama.evalBatchSize/info": "Anger antalet tokens som bearbetas tillsammans i en batch under utvärdering",
+	"embedding.load.llama.ropeFrequencyScale/title": "RoPE-frekvensskalning",
+	"embedding.load.llama.ropeFrequencyScale/subTitle": "Kontextlängden skalas med denna faktor för att förlänga effektiv kontext med RoPE",
+	"embedding.load.llama.ropeFrequencyScale/info": "[Avancerat] Ändrar skalningen av frekvensen för Rotary Positional Encoding för att styra granulariteten i positionsinbäddningen",
+	"embedding.load.llama.acceleration.offloadRatio/title": "GPU-offload",
 	"embedding.load.llama.acceleration.offloadRatio/subTitle": "Antal diskreta modellager att beräkna på GPU för GPU-acceleration",
 	"embedding.load.llama.acceleration.offloadRatio/info": "Ställ in antalet lager som ska avlastas till GPU:n.",
 	"embedding.load.llama.keepModelInMemory/title": "Behåll modell i minnet",
-	"embedding.load.llama.keepModelInMemory/subTitle": "Reservera systemminne för modellen, även när den avlastas till GPU. Förbättrar prestanda men kräver mer system-RAM",
-	"embedding.load.llama.keepModelInMemory/info": "Förhindrar att modellen byts ut till disk, vilket säkerställer snabbare åtkomst på bekostnad av högre RAM-användning",
+	"embedding.load.llama.keepModelInMemory/subTitle": "Reservera systemminne för modellen, även när den avlastas till GPU. Förbättrar prestanda men kräver mer RAM",
+	"embedding.load.llama.keepModelInMemory/info": "Förhindrar att modellen swappas ut till disk, vilket ger snabbare åtkomst på bekostnad av högre RAM-användning",
 	"embedding.load.llama.tryMmap/title": "Försök med mmap()",
-	"embedding.load.llama.tryMmap/subTitle": "Förbättrar laddningstiden för modellen. Att inaktivera detta kan förbättra prestandan när modellen är större än tillgängligt system-RAM",
-	"embedding.load.llama.tryMmap/info": "Ladda modellfiler direkt från disk till minne",
+	"embedding.load.llama.tryMmap/subTitle": "Förbättrar inläsningstiden för modellen. Att inaktivera detta kan förbättra prestandan när modellen är större än tillgängligt systemminne",
+	"embedding.load.llama.tryMmap/info": "Läs in modellfiler direkt från disk till minne",
 	"embedding.load.seed/title": "Seed",
 	"embedding.load.seed/subTitle": "Seed för slumptalsgeneratorn som används vid textgenerering. -1 är slumpmässig",
 
 	"embedding.load.seed/info": "Slumpmässig Seed: Ställer in seed för slumptalsgenerering för att säkerställa reproducerbara resultat",
 
 	"presetTooltip": {
-			"included/title": "Förinställda värden",
-			"included/description": "Följande fält kommer att tillämpas",
-			"included/empty": "Inga fält i denna förinställning gäller i denna kontext.",
-			"included/conflict": "Du kommer att bli ombedd att välja om du vill tillämpa detta värde",
-			"separateLoad/title": "Konfiguration vid laddning",
-			"separateLoad/description.1": "Förinställningen inkluderar också följande konfiguration vid laddning. Konfiguration vid laddning är modellövergripande och kräver omladdning av modellen för att träda i kraft. Håll",
-			"separateLoad/description.2": "för att tillämpa på",
-			"separateLoad/description.3": ".",
-			"excluded/title": "Kanske inte gäller",
-			"excluded/description": "Följande fält ingår i förinställningen men gäller inte i den aktuella kontexten.",
-			"legacy/title": "Legacy-förinställning",
-			"legacy/description": "Denna förinställning är en legacy-förinställning. Den inkluderar följande fält som antingen hanteras automatiskt nu eller inte längre är tillämpliga."
-		},
+		"included/title": "Förinställda värden",
+		"included/description": "Följande fält kommer att tillämpas",
+		"included/empty": "Inga fält i denna förinställning gäller i detta sammanhang.",
+		"included/conflict": "Du kommer att bli ombedd att välja om detta värde ska tillämpas",
+		"separateLoad/title": "Konfiguration vid inläsning",
+		"separateLoad/description.1": "Förinställningen innehåller även följande konfiguration vid inläsning. Konfiguration vid inläsning gäller för hela modellen och kräver att modellen laddas om för att träda i kraft. Håll ned",
+		"separateLoad/description.2": "för att tillämpa på",
+		"separateLoad/description.3": ".",
+		"excluded/title": "Kanske inte gäller",
+		"excluded/description": "Följande fält ingår i förinställningen men gäller inte i det aktuella sammanhanget.",
+		"legacy/title": "Legacy-förinställning",
+		"legacy/description": "Denna förinställning är en äldre förinställning. Den innehåller följande fält som antingen hanteras automatiskt nu eller inte längre är tillämpliga.",
+		"button/publish": "Publicera till Hub",
+		"button/pushUpdate": "Skicka ändringar till Hub",
+		"button/noChangesToPush": "Inga ändringar att skicka",
+		"button/export": "Exportera",
+		"hubLabel": "Förinställning från Hub av {{user}}",
+		"ownHubLabel": "Din förinställning från Hub"
+	},
 
   "customInputs": {
     "string": {
-      "emptyParagraph": "<Empty>"
+      "emptyParagraph": "<Tom>"
     },
-    "checkboxNumeric": {
-      "off": "AV"
+		"checkboxNumeric": {
+			"off": "AV"
+		},
+		"llamaCacheQuantizationType": {
+			"off": "AV"
+		},
+		"mlxKvCacheBits": {
+			"off": "AV"
     },
     "stringArray": {
-      "empty": "<Empty>"
+      "empty": "<Tom>"
     },
-    "llmPromptTemplate": {
-      "type": "Typ",
+		"llmPromptTemplate": {
+			"type": "Typ",
 			"types.jinja/label": "Mall (Jinja)",
-			"jinja.bosToken/label": "BOS Token",
-			"jinja.eosToken/label": "EOS Token",
+			"jinja.bosToken/label": "BOS-token",
+			"jinja.eosToken/label": "EOS-token",
 			"jinja.template/label": "Mall",
-			"jinja/error": "Misslyckades med att tolka Jinja-mallen: {{error}}",
-			"jinja/empty": "Vänligen ange en Jinja-mall ovan.",
-			"jinja/unlikelyToWork": "Jinja-mallen du angav ovan kommer troligen inte att fungera eftersom den inte refererar till variabeln \"messages\". Vänligen dubbelkolla om du har angett en korrekt mall.",
+			"jinja/error": "Misslyckades med att tolka Jinja-mall: {{error}}",
+			"jinja/empty": "Ange en Jinja-mall ovan.",
+			"jinja/unlikelyToWork": "Jinja-mallen du angav ovan verkar inte fungera eftersom den inte refererar till variabeln \"messages\". Kontrollera att du har angett en korrekt mall.",
 			"types.manual/label": "Manuell",
 			"manual.subfield.beforeSystem/label": "Före System",
-			"manual.subfield.beforeSystem/placeholder": "Ange System-prefix...",
+			"manual.subfield.beforeSystem/placeholder": "Ange systemprefix...",
 			"manual.subfield.afterSystem/label": "Efter System",
-			"manual.subfield.afterSystem/placeholder": "Ange System-suffix...",
+			"manual.subfield.afterSystem/placeholder": "Ange systemsuffix...",
 			"manual.subfield.beforeUser/label": "Före Användare",
-			"manual.subfield.beforeUser/placeholder": "Ange Användar-prefix...",
+			"manual.subfield.beforeUser/placeholder": "Ange användarprefix...",
 			"manual.subfield.afterUser/label": "Efter Användare",
-			"manual.subfield.afterUser/placeholder": "Ange Användar-suffix...",
+			"manual.subfield.afterUser/placeholder": "Ange användarsuffix...",
 			"manual.subfield.beforeAssistant/label": "Före Assistent",
-			"manual.subfield.beforeAssistant/placeholder": "Ange Assistent-prefix...",
+			"manual.subfield.beforeAssistant/placeholder": "Ange assistentprefix...",
 			"manual.subfield.afterAssistant/label": "Efter Assistent",
 			"manual.subfield.afterAssistant/placeholder": "Ange Assistent-suffix...",
 			"stopStrings/label": "Ytterligare Stoppsträngar",
 			"stopStrings/subTitle": "Mall-specifika stoppsträngar som kommer att användas utöver användarspecificerade stoppsträngar."
     },
 		"contextLength": {
-			"maxValueTooltip": "Detta är det maximala antalet token som modellen tränades att hantera. Klicka för att ställa in kontexten till detta värde",
+			"maxValueTooltip": "Detta är det maximala antalet token som modellen tränades för att hantera. Klicka för att sätta kontexten till detta värde",
 			"maxValueTextStart": "Modellen stöder upp till",
 			"maxValueTextEnd": "token",
-			"tooltipHint": "Även om en modell kan stödja upp till ett visst antal token, kan prestandan försämras om din maskins resurser inte kan hantera belastningen - var försiktig när du ökar detta värde"
+			"tooltipHint": "Även om en modell kan stödja upp till ett visst antal token, kan prestandan försämras om din dators resurser inte räcker till – var försiktig när du ökar detta värde"
 		},
 		"contextOverflowPolicy": {
 			"stopAtLimit": "Stoppa vid gräns",
-			"stopAtLimitSub": "Sluta generera när modellens minne blir fullt",
+			"stopAtLimitSub": "Sluta generera när modellens minne är fullt",
 			"truncateMiddle": "Trunkera mitten",
-			"truncateMiddleSub": "Tar bort meddelanden från mitten av konversationen för att ge plats åt nyare. Modellen kommer fortfarande att minnas början av konversationen",
+			"truncateMiddleSub": "Tar bort meddelanden från mitten av konversationen för att ge plats åt nya. Modellen kommer fortfarande ihåg början av konversationen",
 			"rollingWindow": "Rullande fönster",
-			"rollingWindowSub": "Modellen kommer alltid att få de senaste meddelandena men kan glömma början av konversationen"
-    },
+			"rollingWindowSub": "Modellen får alltid de senaste meddelandena men kan glömma början av konversationen"
+		},
     "llamaAccelerationOffloadRatio": {
       "max": "MAX",
       "off": "AV"
-    }
+    },
+		"gpuSplitStrategy": {
+			"evenly": "Dela jämnt",
+			"favorMainGpu": "Prioritera huvud-GPU"
+		},
+		"speculativeDecodingDraftModel": {
+			"readMore": "Läs hur det fungerar",
+			"placeholder": "Välj en kompatibel utkastmodell",
+			"noCompatible": "Inga kompatibla utkastmodeller hittades för din nuvarande modellval",
+			"stillLoading": "Identifierar kompatibla utkastmodeller...",
+			"notCompatible": "Den valda utkastmodellen (<draft/>) är inte kompatibel med det aktuella modellvalet (<current/>).",
+			"off": "AV",
+			"loadModelToSeeOptions": "Ladda modell <keyboard-shortcut /> för att se kompatibla alternativ",
+			"compatibleWithNumberOfModels": "Rekommenderas för minst {{dynamicValue}} av dina modeller",
+			"recommendedForSomeModels": "Rekommenderas för vissa modeller",
+			"recommendedForLlamaModels": "Rekommenderas för Llama-modeller",
+			"recommendedForQwenModels": "Rekommenderas för Qwen-modeller",
+			"onboardingModal": {
+			"introducing": "Introducerar",
+			"speculativeDecoding": "Spekulativ avkodning",
+			"firstStepBody": "Snabbare inferens för <custom-span>llama.cpp</custom-span> och <custom-span>MLX</custom-span>-modeller",
+			"secondStepTitle": "Snabbare inferens med spekulativ avkodning",
+			"secondStepBody": "Spekulativ avkodning är en teknik där två modeller samarbetar:\n - En större \"huvud\"modell\n - En mindre \"utkast\"modell\n\nUnder generering föreslår utkastmodellen snabbt tokens som den större huvudmodellen verifierar. Att verifiera tokens är mycket snabbare än att faktiskt generera dem, vilket ger hastighetsvinster. **Generellt gäller att ju större skillnad i storlek mellan huvudmodellen och utkastmodellen, desto större hastighetsökning**.\n\nFör att bibehålla kvalitet accepterar huvudmodellen endast tokens som stämmer överens med vad den själv skulle ha genererat, vilket möjliggör svarskvaliteten från den större modellen men med snabbare inferens. Båda modellerna måste dela samma vokabulär.",
+			"draftModelRecommendationsTitle": "Rekommendationer för utkastmodell",
+			"basedOnCurrentModels": "Baserat på dina nuvarande modeller",
+			"close": "Stäng",
+			"next": "Nästa",
+			"done": "Klar"
+			},
+			"speculativeDecodingLoadModelToSeeOptions": "Ladda först en modell <model-badge /> ",
+			"errorEngineNotSupported": "Spekulativ avkodning kräver minst version {{minVersion}} av motorn {{engineName}}. Uppdatera motorn (<key/>) och ladda om modellen för att använda denna funktion.",
+			"errorEngineNotSupported/noKey": "Spekulativ avkodning kräver minst version {{minVersion}} av motorn {{engineName}}. Uppdatera motorn och ladda om modellen för att använda denna funktion."
+		},
+		"llmReasoningParsing": {
+			"startString/label": "Startsträng",
+			"startString/placeholder": "Ange startsträng...",
+			"endString/label": "Slutsträng",
+			"endString/placeholder": "Ange slutsträng..."
+		}
   },
 	"saveConflictResolution": {
 		"title": "Välj vilka värden som ska inkluderas i förinställningen",
-		"description": "Välj och välj vilka värden du vill behålla",
+		"description": "Välj vilka värden du vill behålla",
 		"instructions": "Klicka på ett värde för att inkludera det",
 		"userValues": "Tidigare värde",
 		"presetValues": "Nytt värde",
@@ -217,31 +323,38 @@
 	},
 	"applyConflictResolution": {
 		"title": "Vilka värden ska behållas?",
-		"description": "Du har obekräftade ändringar som överlappar med den inkommande förinställningen",
+		"description": "Du har osparade ändringar som överlappar med den inkommande förinställningen",
 		"instructions": "Klicka på ett värde för att behålla det",
 		"userValues": "Nuvarande värde",
 		"presetValues": "Inkommande förinställningsvärde",
 		"confirm": "Bekräfta",
 		"cancel": "Avbryt"
 	},
-	"empty": "<Empty>",
-  "presets": {
+	"empty": "<Tom>",
+	"noModelSelected": "Ingen modell vald",
+	"apiIdentifier.label": "API-identifierare",
+	"apiIdentifier.hint": "Ange valfritt en identifierare för denna modell. Den kommer att användas i API-förfrågningar. Lämna tomt för att använda standardidentifieraren.",
+	"idleTTL.label": "Ladda ur automatiskt vid inaktivitet (TTL)",
+	"idleTTL.hint": "Om angivet kommer modellen automatiskt att laddas ur efter att ha varit inaktiv under angiven tid.",
+	"idleTTL.mins": "min",
+
+	"presets": {
 		"title": "Förinställning",
-		"commitChanges": "Verkställ ändringar",
-		"commitChanges/description": "Verkställ dina ändringar till förinställningen.",
+		"commitChanges": "Spara ändringar",
+		"commitChanges/description": "Spara dina ändringar i förinställningen.",
 		"commitChanges.manual": "Nya fält upptäckta. Du kommer att kunna välja vilka ändringar som ska inkluderas i förinställningen.",
-		"commitChanges.manual.hold.0": "Håll",
-		"commitChanges.manual.hold.1": "för att välja vilka ändringar som ska verkställas till förinställningen.",
-		"commitChanges.saveAll.hold.0": "Håll",
+		"commitChanges.manual.hold.0": "Håll ned",
+		"commitChanges.manual.hold.1": "för att välja vilka ändringar som ska sparas i förinställningen.",
+		"commitChanges.saveAll.hold.0": "Håll ned",
 		"commitChanges.saveAll.hold.1": "för att spara alla ändringar.",
-		"commitChanges.saveInPreset.hold.0": "Håll",
-		"commitChanges.saveInPreset.hold.1": "för att endast spara ändringar till fält som redan är inkluderade i förinställningen.",
-		"commitChanges/error": "Misslyckades med att verkställa ändringar till förinställningen.",
+		"commitChanges.saveInPreset.hold.0": "Håll ned",
+		"commitChanges.saveInPreset.hold.1": "för att endast spara ändringar i fält som redan ingår i förinställningen.",
+		"commitChanges/error": "Misslyckades med att spara ändringar i förinställningen.",
 		"commitChanges.manual/description": "Välj vilka ändringar som ska inkluderas i förinställningen.",
-		"saveAs": "Spara som...",
+		"saveAs": "Spara som ny...",
 		"presetNamePlaceholder": "Ange ett namn för förinställningen...",
-		"cannotCommitChangesLegacy": "Detta är en legacy-förinställning och kan inte modifieras. Du kan skapa en kopia genom att använda \"Spara som ny...\".",
-		"cannotCommitChangesNoChanges": "Inga ändringar att verkställa.",
+		"cannotCommitChangesLegacy": "Detta är en äldre förinställning och kan inte ändras. Du kan skapa en kopia genom att använda \"Spara som ny...\".",
+		"cannotCommitChangesNoChanges": "Inga ändringar att spara.",
 		"emptyNoUnsaved": "Välj en förinställning...",
 		"emptyWithUnsaved": "Osparad förinställning",
 		"saveEmptyWithUnsaved": "Spara förinställning som...",
@@ -253,16 +366,217 @@
 		"deselect/error": "Misslyckades med att avmarkera förinställningen.",
 		"select/error": "Misslyckades med att välja förinställning.",
 		"delete/error": "Misslyckades med att radera förinställning.",
-		"discardChanges": "Kassera osparade",
-		"discardChanges/info": "Kassera alla icke-verkställda ändringar och återställ förinställningen till dess ursprungliga tillstånd",
-		"newEmptyPreset": "Skapa ny tom förinställning...",
-		"contextMenuSelect": "Välj förinställning",
-		"contextMenuDelete": "Radera"
+		"discardChanges": "Kasta osparade",
+		"discardChanges/info": "Kasta alla osparade ändringar och återställ förinställningen till ursprungligt tillstånd",
+		"newEmptyPreset": "+ Ny förinställning",
+		"importPreset": "Importera",
+		"contextMenuCopyIdentifier": "Kopiera förinställnings-ID",
+		"contextMenuSelect": "Använd förinställning",
+		"contextMenuDelete": "Ta bort...",
+		"contextMenuShare": "Publicera...",
+		"contextMenuOpenInHub": "Visa på webben",
+		"contextMenuPullFromHub": "Hämta senaste",
+		"contextMenuPushChanges": "Skicka ändringar till Hub",
+		"contextMenuPushingChanges": "Skickar...",
+		"contextMenuPushedChanges": "Ändringar skickade",
+		"contextMenuExport": "Exportera fil",
+		"contextMenuRevealInExplorer": "Visa i Utforskaren",
+		"contextMenuRevealInFinder": "Visa i Finder",
+		"share": {
+			"title": "Publicera förinställning",
+			"action": "Dela din förinställning så att andra kan ladda ner, gilla och förgrena den",
+			"presetOwnerLabel": "Ägare",
+			"uploadAs": "Din förinställning kommer att skapas som {{name}}",
+			"presetNameLabel": "Förinställningsnamn",
+			"descriptionLabel": "Beskrivning (valfritt)",
+			"loading": "Publicerar...",
+			"success": "Förinställning publicerad",
+			"presetIsLive": "<preset-name /> är nu live på Hub!",
+			"close": "Stäng",
+			"confirmViewOnWeb": "Visa på webben",
+			"confirmCopy": "Kopiera URL",
+			"confirmCopied": "Kopierad!",
+			"pushedToHub": "Din förinställning har skickats till Hub",
+			"descriptionPlaceholder": "Ange en beskrivning...",
+			"willBePublic": "Denna förinställning blir offentlig. Alla på internet kan se den.",
+			"willBePrivate": "Endast du kan se denna förinställning",
+			"willBeOrgVisible": "Denna förinställning blir synlig för alla i organisationen.",
+			"publicSubtitle": "Din förinställning är <custom-bold>Offentlig</custom-bold>. Andra kan ladda ner och förgrena den på lmstudio.ai",
+			"privateUsageReached": "Gränsen för antal privata förinställningar har uppnåtts.",
+			"continueInBrowser": "Fortsätt i webbläsare",
+			"confirmShareButton": "Publicera",
+			"error": "Misslyckades med att publicera förinställning",
+			"createFreeAccount": "Skapa ett gratis konto i Hub för att publicera förinställningar"
+		},
+		"update": {
+			"title": "Skicka ändringar till Hub",
+			"title/success": "Förinställning uppdaterad",
+			"subtitle": "Gör ändringar i <custom-preset-name /> och skicka dem till Hub",
+			"descriptionLabel": "Beskrivning",
+			"descriptionPlaceholder": "Ange en beskrivning...",
+			"loading": "Skickar...",
+			"cancel": "Avbryt",
+			"createFreeAccount": "Skapa ett gratis konto i Hub för att publicera förinställningar",
+			"error": "Misslyckades med att skicka uppdatering",
+			"confirmUpdateButton": "Skicka"
+		},
+		"resolve": {
+			"title": "Lös konflikter...",
+			"tooltip": "Öppna en dialog för att lösa skillnader med Hub-versionen"
+		},
+		"loginToManage": {
+			"title": "Logga in för att hantera..."
+		},
+		"downloadFromHub": {
+			"title": "Ladda ner",
+			"downloading": "Laddar ner...",
+			"success": "Nedladdad!",
+			"error": "Misslyckades med att ladda ner"
+		},
+		"push": {
+			"title": "Skicka ändringar",
+			"pushing": "Skickar...",
+			"success": "Skickad",
+			"tooltip": "Skicka dina lokala ändringar till den fjärrversion som finns på Hub",
+			"error": "Misslyckades med att skicka"
+		},
+		"saveAsNewModal": {
+			"title": "Hoppsan! Hittade inte förinställningen på Hub",
+			"confirmSaveAsNewDescription": "Vill du publicera denna förinställning som en ny?",
+			"confirmButton": "Publicera som ny"
+		},
+		"pull": {
+			"title": "Hämta senaste",
+			"error": "Misslyckades med att hämta",
+			"contextMenuErrorMessage": "Misslyckades med att hämta",
+			"success": "Hämtad",
+			"pulling": "Hämtar...",
+			"upToDate": "Uppdaterad!",
+			"unsavedChangesModal": {
+				"title": "Du har osparade ändringar.",
+				"bodyContent": "Att hämta från fjärrenheten kommer att skriva över dina osparade ändringar. Fortsätt?",
+				"confirmButton": "Skriv över osparade ändringar"
+			}
+		},
+		"import": {
+			"title": "Importera en förinställning från fil",
+			"dragPrompt": "Dra och släpp förinställningsfiler (.tar.gz eller preset.json) eller <custom-link>välj från din dator</custom-link>",
+			"remove": "Ta bort",
+			"cancel": "Avbryt",
+			"importPreset_zero": "Importera förinställning",
+			"importPreset_one": "Importera förinställning",
+			"importPreset_other": "Importera {{count}} förinställningar",
+			"selectDialog": {
+				"title": "Välj förinställningsfil (preset.json eller .tar.gz)",
+				"button": "Importera"
+			},
+			"error": "Misslyckades med att importera förinställning",
+			"resultsModal": {
+				"titleSuccessSection_one": "1 förinställning importerad",
+				"titleSuccessSection_other": "{{count}} förinställningar importerade",
+				"titleFailSection_zero": "",
+				"titleFailSection_one": "({{count}} misslyckades)",
+				"titleFailSection_other": "({{count}} misslyckades)",
+				"titleAllFailed": "Misslyckades med att importera förinställningar",
+				"importMore": "Importera fler",
+				"close": "Klar",
+				"successBadge": "Lyckades",
+				"alreadyExistsBadge": "Förinställning finns redan",
+				"errorBadge": "Fel",
+				"invalidFileBadge": "Ogiltig fil",
+				"otherErrorBadge": "Misslyckades med att importera förinställning",
+				"errorViewDetailsButton": "Visa detaljer",
+				"seeError": "Visa fel",
+				"noName": "Inget namn",
+				"useInChat": "Använd i chatt"
+			},
+			"importFromUrl": {
+				"button": "Importera från URL...",
+				"title": "Importera från URL",
+				"back": "Importera från fil...",
+				"action": "Klistra in LM Studio Hub-URL:en för förinställningen du vill importera nedan",
+				"invalidUrl": "Ogiltig URL. Kontrollera att du klistrar in en korrekt LM Studio Hub-URL.",
+				"tip": "Du kan installera förinställningen direkt med knappen {{buttonName}} i LM Studio Hub",
+				"confirm": "Importera",
+				"cancel": "Avbryt",
+				"loading": "Importerar...",
+				"error": "Misslyckades med att ladda ner förinställning."
+			}
+		},
+		"download": {
+			"title": "Hämta <preset-name /> från LM Studio Hub",
+			"subtitle": "Spara <custom-name /> till dina förinställningar. Då kan du använda denna förinställning i appen",
+			"button": "Hämta",
+			"button/loading": "Hämtar...",
+			"cancel": "Avbryt",
+			"error": "Misslyckades med att ladda ner förinställning."
+		},
+		"inclusiveness": {
+			"speculativeDecoding": "Inkludera i förinställning"
+		}
 	},
 
 	"flashAttentionWarning": "Flash Attention är en experimentell funktion som kan orsaka problem med vissa modeller. Om du stöter på problem, försök att inaktivera den.",
-	
+	"llamaKvCacheQuantizationWarning": "KV-cache-kvantisering är en experimentell funktion som kan orsaka problem med vissa modeller. Flash Attention måste vara aktiverat för V-cache-kvantisering. Om du stöter på problem, återställ till standardvärdet \"F16\".",
+
 	"seedUncheckedHint": "Slumpmässig Seed",
 	"ropeFrequencyBaseUncheckedHint": "Auto",
-	"ropeFrequencyScaleUncheckedHint": "Auto"
+	"ropeFrequencyScaleUncheckedHint": "Auto",
+
+	"hardware": {
+		"environmentVariables": "Miljövariabler",
+		"environmentVariables.info": "Om du är osäker, lämna dessa på standardvärdena",
+		"environmentVariables.reset": "Återställ till standard",
+
+		"gpus.information": "Konfigurera grafikkort (GPU:er) som upptäckts på din dator",
+		"gpuSettings": {
+			"editMaxCapacity": "Redigera maxkapacitet",
+			"hideEditMaxCapacity": "Dölj redigera maxkapacitet",
+			"allOffWarning": "Alla GPU:er är avstängda eller inaktiverade, se till att det finns någon GPU-allokering för att kunna ladda modeller",
+			"split": {
+				"title": "Strategi",
+				"placeholder": "Välj en GPU-minnesallokering",
+				"options": {
+					"generalDescription": "Konfigurera hur modeller ska laddas på dina GPU:er",
+					"evenly": {
+						"title": "Dela jämnt",
+						"description": "Allokera minne jämnt över GPU:erna"
+					},
+					"priorityOrder": {
+						"title": "Prioritetsordning",
+						"description": "Dra för att ändra prioritet. Systemet försöker allokera mer på GPU:er som listas först"
+					},
+					"custom": {
+						"title": "Anpassad",
+						"description": "Allokera minne",
+						"maxAllocation": "Maximal allokering"
+					}
+				}
+			},
+			"deviceId.info": "Unik identifierare för denna enhet",
+			"changesOnlyAffectNewlyLoadedModels": "Ändringar påverkar endast nyligen inlästa modeller",
+			"toggleGpu": "Aktivera/Inaktivera GPU"
+		}
+	},
+
+	"load.gpuSplitConfig/title": "GPU-splitkonfiguration",
+	"envVars/title": "Ställ in en miljövariabel",
+	"envVars": {
+		"select": {
+			"placeholder": "Välj en miljövariabel...",
+			"noOptions": "Inga fler tillgängliga",
+			"filter": {
+				"placeholder": "Filtrera sökresultat",
+				"resultsFound_zero": "Inga resultat hittades",
+				"resultsFound_one": "1 resultat hittades",
+				"resultsFound_other": "{{count}} resultat hittades"
+			}
+		},
+		"inputValue": {
+			"placeholder": "Ange ett värde"
+		},
+		"values": {
+			"title": "Nuvarande värden"
+		}
+  }
 }

--- a/sv/developer.json
+++ b/sv/developer.json
@@ -26,11 +26,28 @@
 	"serverOptions/verboseLogging/subtitle": "Aktivera detaljerad loggning för den lokala servern",
 	"serverOptions/contentLogging/title": "Logga uppmaningar och svar",
 	"serverOptions/contentLogging/subtitle": "Inställningar för lokal begäran / svar loggning",
+	"serverOptions/redactContent/title": "Maskera innehåll",
+	"serverOptions/redactContent/hint": "När aktiverat förhindras känslig data, såsom innehållet i förfrågningar och svar, från att loggas.",
 	"serverOptions/contentLogging/hint": "Om uppmaningar och/eller svar ska loggas i den lokala serverns loggfil.",
+	"serverOptions/logIncomingTokens/title": "Logga inkommande token",
+	"serverOptions/logIncomingTokens/hint": "Om varje token ska loggas när de genereras.",
+	"serverOptions/fileLoggingMode/title": "Fil-loggningsläge",
+	"serverOptions/fileLoggingMode/off/title": "AV",
+	"serverOptions/fileLoggingMode/off/hint": "Skapa inga loggfiler",
+	"serverOptions/fileLoggingMode/succinct/title": "Kortfattat",
+	"serverOptions/fileLoggingMode/succinct/hint": "Logga samma innehåll som i konsolen. Långa förfrågningar kommer att trunkeras.",
+	"serverOptions/fileLoggingMode/full/title": "Fullständigt",
+	"serverOptions/fileLoggingMode/full/hint": "Trunkera inte långa förfrågningar.",
 	"serverOptions/jitModelLoading/title": "Just-in-Time modellinläsning",
 	"serverOptions/jitModelLoading/hint": "När aktiverad, om en begäran specificerar en modell som inte är inläst, kommer den automatiskt att laddas och användas. Dessutom kommer \"/v1/models\"-endpointen också att inkludera modeller som ännu inte är inlästa.",
 	"serverOptions/loadModel/error": "Misslyckades med att ladda modell",
-	
+	"serverOptions/jitModelLoadingTTL/title": "Autoavlasta oanvända JIT-inlästa modeller",
+	"serverOptions/jitModelLoadingTTL/hint": "En modell som laddats Just-in-time (JIT) för att hantera en API-förfrågan kommer automatiskt att avlastas efter att ha varit oanvänd en viss tid (TTL).",
+	"serverOptions/jitModelLoadingTTL/ttl/label": "Max inaktiv TTL",
+	"serverOptions/jitModelLoadingTTL/ttl/unit": "minuter",
+	"serverOptions/unloadPreviousJITModelOnLoad/title": "Behåll endast senaste JIT-inlästa modell",
+	"serverOptions/unloadPreviousJITModelOnLoad/hint": "Säkerställ att högst 1 modell är inläst via JIT åt gången (avlastar föregående modell)",
+
 	"serverLogs/scrollToBottom": "Hoppa till botten",
 	"serverLogs/clearLogs": "Rensa loggar ({{shortcut}})",
 	"serverLogs/openLogsFolder": "Öppna serverloggsmappen",
@@ -42,6 +59,12 @@
 	"runtimeSettings/chooseRuntime/showAllVersions/hint": "Som standard visar LM Studio endast den senaste versionen av varje kompatibel körmiljö. Aktivera detta alternativ för att se alla tillgängliga körmiljöer.",
 	"runtimeSettings/chooseRuntime/select/placeholder": "Välj en körmiljö",
 	
+	"runtimeSettings/chooseFrameworks/title": "Ramverk",
+	"runtimeSettings/chooseFrameworks/description": "Välj ett ramverk att använda för varje funktionalitet",
+	"runtimeSettings/chooseFramework/documentParser/builtIn/label": "Inbyggd tolk",
+	"runtimeSettings/chooseFramework/documentParser/select/label": "Dokumenttolk",
+	"runtimeSettings/chooseFramework/documentParser/select/placeholder": "Välj en dokumenttolk",
+
 	"runtimeOptions/uninstall": "Avinstallera",
 	"runtimeOptions/uninstallDialog/title": "Avinstallera {{runtimeName}}?",
 	"runtimeOptions/uninstallDialog/body": "Avinstallation av denna körmiljö kommer att ta bort den från systemet. Denna åtgärd är oåterkallelig.",
@@ -53,16 +76,104 @@
 	"runtimeOptions/downloadIncompatibleRuntime": "Denna körmiljö bedömdes vara inkompatibel med din maskin. Den kommer troligen inte att fungera.",
 	"runtimeOptions/noRuntimes": "Inga körmiljöer hittades",
 	
+		"runtimes": {
+		"manageLMRuntimes": "Hantera LM-körmiljöer",
+		"includeOlderRuntimeVersions": "Inkludera äldre versioner",
+		"dismiss": "Avfärda",
+		"updateAvailableToast": {
+			"title": "Uppdatering av LM-körmiljö tillgänglig!"
+		},
+		"updatedToast": {
+			"title": "✅ LM-körmiljö uppdaterad: {{runtime}} → v{{version}}",
+			"preferencesUpdated": "Nyligen inlästa {{compatibilityTypes}} modeller kommer att använda den uppdaterade körmiljön."
+		},
+		"noAvx2ErrorMessage": "Alla LM-körmiljöer kräver för närvarande en CPU med AVX2-stöd",
+		"downloadableRuntimes": {
+			"runtimeExtensionPacks": "Körmiljöpaket",
+			"refresh": "Uppdatera",
+			"refreshing": "Uppdaterar...",
+			"filterSegment": {
+				"compatibleOnly": "Endast kompatibla",
+				"all": "Alla"
+			},
+			"card": {
+				"releaseNotes": "Versionsanteckningar",
+				"latestVersionInstalled": "Senaste versionen installerad",
+				"updateAvailable": "Uppdatering tillgänglig"
+			}
+		},
+		"installedRuntimes": {
+			"manage": {
+				"title": "Hantera aktiva körmiljöer"
+			},
+			"dropdownOptions": {
+				"installedVersions": "Hantera versioner",
+				"close": "Stäng"
+			},
+			"tabs": {
+				"all": "Alla",
+				"frameworks": "Mina ramverk",
+				"engines": "Mina motorer"
+			},
+			"detailsModal": {
+				"installedVersions": "Installerade versioner för {{runtimeName}}",
+				"manifestJsonTitle": "Manifest JSON (avancerat)",
+				"releaseNotesTitle": "Versionsanteckningar",
+				"noReleaseNotes": "Inga versionsanteckningar tillgängliga för denna version",
+				"back": "Tillbaka",
+				"close": "Stäng"
+			},
+			"noEngines": "Inga motorer installerade",
+			"noFrameworks": "Inga ramverk installerade"
+		}
+	},
+
 	"inferenceParams/noParams": "Inga konfigurerbara prediktionsparametrar tillgängliga för denna modelltyp",
 	
+	"quickDocs": {
+		"tabChipTitle": "Snabbdokumentation",
+		"newToolUsePopover": "Kodexempel finns nu här i \"Snabbdokumentation\". Klicka här för att komma igång med verktygsanvändning!",
+		"newToolUsePopoverTitle": "📚 Snabbdokumentation",
+		"learnMore": "ℹ️ 👾 För att lära dig mer om LM Studio:s lokala serverendpoints, besök [dokumentationen](https://lmstudio.ai/docs).",
+		"helloWorld": {
+			"title": "Hej, världen!"
+		},
+		"chat": {
+			"title": "Chatt"
+		},
+		"structuredOutput": {
+			"title": "Strukturerad utdata"
+		},
+		"imageInput": {
+			"title": "Bildinmatning"
+		},
+		"embeddings": {
+			"title": "Inbäddningar"
+		},
+		"toolUse": {
+			"title": "Verktygsanvändning",
+			"tab": {
+				"saveAsPythonFile": "Spara som Python-fil",
+				"runTheScript": "Kör skriptet:",
+				"savePythonFileCopyPaste": "Spara som Python-fil för kopiera-och-klistra-in-kommando"
+			}
+		},
+		"newBadge": "Ny"
+	},
+
 	"endpoints/openaiCompatRest/title": "Stödda slutpunkter (OpenAI-liknande)",
 	"endpoints/openaiCompatRest/getModels": "Lista de för närvarande inlästa modellerna",
 	"endpoints/openaiCompatRest/postCompletions": "Textkompletteringsläge. Förutsäg nästa token(s) givet en prompt. Obs: OpenAI anser att denna slutpunkt är 'föråldrad'.",
 	"endpoints/openaiCompatRest/postChatCompletions": "Chattkompletteringar. Skicka en chattlogg till modellen för att förutsäga nästa assistentsvar",
 	"endpoints/openaiCompatRest/postEmbeddings": "Textinbäddning. Generera textinbäddningar för en given textinmatning. Tar en sträng eller en array av strängar.",
-	
+
 	"model.createVirtualModelFromInstance": "Spara inställningar som en ny virtuell modell",
 	"model.createVirtualModelFromInstance/error": "Misslyckades med att spara inställningar som en ny virtuell modell",
-	
+
+	"model": {
+		"toolUseSectionTitle": "Verktygsanvändning",
+		"toolUseDescription": "Denna modell har identifierats som tränad för verktygsanvändning\n\nÖppna <custom-link>snabbdokumentation</custom-link> för mer information"
+	},
+
 	"apiConfigOptions/title": "API-konfiguration"
 }

--- a/sv/discover.json
+++ b/sv/discover.json
@@ -23,6 +23,7 @@
   "download.option.recommended/description": "Baserat på din hårdvara rekommenderas detta alternativ.",
   "download.option.downloaded/title": "Nedladdad",
   "download.option.downloading/title": "Laddar ner ({{progressPercentile}}%)",
+  "failedToStartDownload": "Det gick inte att starta nedladdningen",
 
   "feed.action.refresh": "Uppdatera flöde"
 }

--- a/sv/download.json
+++ b/sv/download.json
@@ -1,5 +1,15 @@
 {
   "postDownloadActionExecutor.zipExtraction/status": "Extraherar...",
+  "postDownloadActionExecutor.tarGzExtraction/status": "Extraherar filer...",
+  "postDownloadActionExecutor.runtimeIndexerTarGzExtraction/status": "Extraherar filer...",
+  "postDownloadActionExecutor.modifyModelData/status": "Uppdaterar modelldata...",
+  "postDownloadActionExecutor.notification/status": "Notifierar användare...",
+  "postDownloadActionExecutor.writeString/status": "Skriver metadata...",
+  "postDownloadActionExecutor.updateSelectedBackendVersions/status": "Uppdaterar vald version...",
+  "postDownloadActionExecutor.extensionPackAutoDeletion/status": "Tar bort oanvända tillägg...",
+  "postDownloadActionExecutor.pluginInstall/status": "Installerar plugin...",
+  "postDownloadActionExecutor.pluginUninstall/status": "Avinstallerar plugin...",
+
   "finalizing": "Slutför nedladdning... (detta kan ta en stund)",
   "noOptions": "Inga kompatibla alternativ tillgängliga för nedladdning",
   
@@ -19,5 +29,15 @@
 
   "downloadsPanel/title": "Nedladdningar",
   "downloadsPanel/sectionTitle/ongoing": "Pågående",
-  "downloadsPanel/sectionTitle/completed": "Slutförda"
+  "downloadsPanel/sectionTitle/completed": "Slutförda",
+  "downloadsPanel": {
+    "reveal": {
+      "mac": "Visa i Finder",
+      "mac/error": "Kunde inte visa i Finder",
+      "nonMac": "Visa i Utforskaren",
+      "nonMac/error": "Kunde inte visa i Utforskaren"
+    },
+    "completed": "Nedladdning slutförd",
+    "loadModel": "Ladda modell"
+  }
 }

--- a/sv/models.json
+++ b/sv/models.json
@@ -12,30 +12,22 @@
 	"modelsTable.arch/label": "Arkitektur",
 	"modelsTable.params/label": "Parametrar",
 	"modelsTable.publisher/label": "Utgivare",
-	"modelsTable.llms/label": "LLM",
-	"modelsTable.embeddingModels/label": "Inbäddningsmodell",
-	"modelsTable.quant/label": "Kvant",
+	"modelsTable.displayName/label": "Namn",
+	"modelsTable.modelKey/label": "Modellnyckel",
 	"modelsTable.size/label": "Storlek",
 	"modelsTable.dateModified/label": "Ändringsdatum",
 	"modelsTable.actions/label": "Åtgärder",
+	
+	"modelsTable.llms/label": "LLM",
+	"modelsTable.embeddingModels/label": "Inbäddningsmodell",
+	"modelsTable.quant/label": "Kvant",
 	
 	"action.model.delete": "Radera",
 	"action.model.delete.full": "Radera modell",
 	"action.model.delete.confirmation/title": "Radera {{name}}",
 	"action.model.delete.confirmation/description": "Är du säker? Detta kommer permanent att radera alla filer associerade med denna modell från din maskin. Denna åtgärd är oåterkallelig.",
 	"action.model.delete.confirmation/confirm": "Radera",
-	
-	"action.createVirtual": "Skapa förinställning",
-	"action.createVirtual.details/title": "Skapa en förinställning",
-	"action.createVirtual.details/create": "Skapa",
-	"action.createVirtual.details/cancel": "Avbryt",
-	"action.createVirtual.details.base/label": "Basmodell",
-	"action.createVirtual.details.name/label": "Namn",
-	"action.createVirtual.details.includeMachineDependent/label": "Inkludera maskinberoende konfigurationer",
-	"action.createVirtual.details.includeMachineDependent/hint": "Om datorberoende konfigurationer (såsom GPU-inställningar) ska inkluderas i förinställningen. Rekommenderas inte för delning.",
-	"action.createVirtual.details.config/label": "Anpassade konfigurationer",
-	"action.createVirtual.details.config.empty": "Inga anpassade konfigurationer",
-	"action.createVirtual.details/error": "Misslyckades med att skapa virtuell modell.",
+	"action.model.delete/error": "Misslyckades med att radera modell",
 
 	"loader.model.bundled": "bundlad",
 	"action.cancel": "Avbryt",
@@ -50,12 +42,19 @@
 	"unresolvedVirtualModels/title_other": "Misslyckades med att lösa följande virtuella modeller:",
 	"unresolvedVirtualModels.missingModel": "En beroendemodell saknas: {{missing}}. Beroendekedja:\n{{chain}}",
 	"unresolvedVirtualModels.circular": "Cirkulärt beroende upptäckt.",
-	
+	"unresolvedVirtualModels.fix": "Åtgärda",
+	"unresolvedVirtualModels.revealInExplorer": "Visa i Utforskaren",
+	"unresolvedVirtualModels.revealInFinder": "Visa i Finder",
+	"unresolvedVirtualModels.reveal/error": "Misslyckades med att visa",
+
 	"modelsDirectory": "Modellkatalog",
 	"modelsDirectory.change": "Ändra...",
+	"modelsDirectory.change/error": "Failed to change models directory",
 	"modelsDirectory.reset": "Återställ till standardväg",
 	"modelsDirectory.reveal.mac": "Visa i Finder",
 	"modelsDirectory.reveal.nonMac": "Öppna i Utforskaren",
+	"modelsDirectory.reveal.mac/error": "Misslyckades med att öppna i Finder",
+	"modelsDirectory.reveal.nonMac/error": "Misslyckades med att öppna i Utforskaren",
 	"modelsDirectory.forceReindex": "Uppdatera",
 	"loadState/loaded": "Inläst",
 	"loadState/loading": "Läser in",
@@ -68,18 +67,49 @@
 	"contextMenu/unpin": "Ta bort nål",
 	"contextMenu/copyAbsolutePath": "Kopiera absolut sökväg",
 	"contextMenu/copyModelName": "Kopiera modellsökväg",
+	"contextMenu/copyModelDefaultIdentifier": "Kopiera standardidentifierare",
+	"contextMenu/showRawMetadata": "Visa råmetadata",
 	"contextMenu/openOnHuggingFace": "Öppna på Hugging Face",
+	"contextMenu": {
+		"showOnWeb": "Visa på webben",
+		"pullLatest": {
+			"label": "Hämta senaste",
+			"checking": "Letar efter uppdateringar...",
+			"upToDate": "Uppdaterad",
+			"error": "Misslyckades med att leta efter uppdateringar"
+		}
+	},
 	"tooltip/moreActions": "Fler åtgärder",
 	"tooltip/getInfo": "Få information",
 	"tooltip/editModelDefaultConfig": "Redigera modellens standardkonfiguration",
 	"tooltip/editModelDefaultConfig/override": "Redigera modellens standardkonfiguration (* har för närvarande ändringar)",
 	"tooltip/visionBadge": "Denna modell kan bearbeta bildinmatningar",
-	
+	"tooltip/toolUseBadge": "Denna modell har tränats för verktygsanvändning",
+
 	"visionBadge/label": "Visning aktiverad",
-	
+	"toolUseBadge/label": "Tränad för verktygsanvändning",
+
 	"loader.action.load": "Ladda modell",
 	"loader.action.clearChanges": "Återställ ändringar",
 	"loader.action.cancel": "Avbryt",
 	"loader.info.clickOnModelToLoad": "Klicka på en modell för att ladda den",
-	"loader.info.configureLoadParameters": "Konfigurera modellens inläsningsparametrar"
+	"loader.info.configureLoadParameters": "Konfigurera modellens inläsningsparametrar",
+	"loader.info.activeGeneratorWarning": "Du använder ett plugin med en anpassad generator. Din nuvarande inlästa modell kan eller kan inte användas under detta plugin, beroende på generatorns implementation.",
+
+	"virtual": {
+		"local": {
+			"create": "Skapa virtuell modell",
+			"title": "Skapa en lokal virtuell modell",
+			"description": "Skapa en virtuell modell genom att bunta en modell med en uppsättning konfigurationer. De underliggande vikterna kommer inte att dupliceras.",
+			"modelKey.label": "Modellnyckel",
+			"modelKey.placeholder": "Ange en unik modellnyckel",
+			"modelKey.normalized": "Din modellnyckel kommer att normaliseras till: {{normalized}}",
+			"baseModel.label": "Basmodell",
+			"baseModel.placeholder": "Välj en basmodell",
+			"baseModel.empty": "Ladda ner en modell att använda som basmodell",
+			"next": "Nästa",
+			"confirm": "Skapa",
+			"error": "Misslyckades med att skapa virtuell modell"
+		}
+	}
 }

--- a/sv/onboarding.json
+++ b/sv/onboarding.json
@@ -20,5 +20,23 @@
         "description": "LLM kommer att titta på din fråga och de hämtade utdragen från dina dokument, och försöka generera ett svar. Experimentera med olika frågor för att hitta vad som fungerar bäst."
       }
     }
+  },
+
+  "toolUse": {
+    "step_0": {
+      "title": "Beta: Verktygsanvändning 🛠️ (Funktionsanrop)",
+      "text_0": "Vissa modeller (t.ex. Llama 3.1/3.2, Mistral, Qwen och fler) har tränats för att använda verktyg.",
+      "text_1": "I praktiken innebär detta: du tillhandahåller en array av 'verktyg' (funktionssignaturer) till LLM i ett mycket specifikt format, och LLM kan välja att 'anropa' dem baserat på användarens prompt.",
+      "text_2": "Du kan tänka dig användningsområden som att fråga ett API, köra kod, eller egentligen vad som helst som kan uttryckas som ett funktionsanrop."
+    },
+    "step_1": {
+      "title": "Kom igång med Verktygsanvändning",
+      "toolUseCanWorkWithAnyModel": "Modeller som har tränats för verktygsanvändning presterar bättre än andra, men du kan försöka använda verktyg med vilken modell som helst. Läs <customlink>dokumentationen</customlink> för att lära dig mer.\nModeller som har tränats för verktygsanvändning kommer att markeras med en ny badge:",
+      "hasCompatibleModel": "🎉 Det ser ut som att du redan har modeller med verktygsstöd!",
+      "downloadRecommendedModel": "Ladda ner en modell som har tränats för verktygsanvändning:"
+    },
+    "nextButton": "Nästa",
+    "letsGoButton": "Ladda modell och starta server",
+    "doneButton": "Stäng"
   }
 }

--- a/sv/settings.json
+++ b/sv/settings.json
@@ -1,12 +1,13 @@
 {
 	"settingsDialogTitle": "Appinställningar",
 	"settingsDialogButtonTooltip": "Appinställningar",
-	
+	"accountDialogButtonTooltip": "Konto",
+
 	"settingsNewButtonPopover": {
 		"primary": "Appinställningar finns nu i det nedre högra hörnet",
 		"secondary": "Klicka på ⚙️-knappen för att öppna dem.",
 		"tertiary": "Eller tryck på"
-  },
+	},
 	"appUpdate": "Appuppdatering",
 	"checkingAppUpdate": "Söker efter uppdateringar...",
 	"checkForUpdates": "Sök efter uppdateringar",
@@ -23,6 +24,7 @@
 	"yourCurrentVersion": "Du använder för närvarande:",
 	"latestVersion": "Den senaste versionen är:",
 	"downloadLabel": "Uppdatera nu",
+	"downloadLabel/Linux": "Ladda ner uppdatering",
 	"cancelDownloadLabel": "Avbryt",
 	"downloadingUpdate": "Laddar ner uppdatering...",
 	"updateDownloaded": "Ny uppdatering nedladdad framgångsrikt. Starta om appen för att tillämpa uppdateringen.",
@@ -30,6 +32,9 @@
 	"appUpdatedToastTitle": "Uppdaterad till {{title}}",
 	"appUpdatedToastDescriptionPrefix": "Visa ",
 	"AppUpdatedToastDescriptionReleaseNotes": "Versionsanteckningar",
+	"toolUseToastTitle": "Nytt i Beta: Verktygsanvändning och Function Calls API",
+	"toolUseToastDescription": "Drop-in-ersättning för OpenAI Tool Use med utvalda modeller som Llama 3.1/3.2, Mistral och Qwen.",
+	"toolUseToastButtonText": "Gå till utvecklarsidan för att prova",
 	"doItLater": "Jag gör det senare",
 	"failedToUpdate": "Appuppdatering misslyckades. Kontrollera din internetanslutning eller försök igen senare.",
 	"retryInBackground": "Försök igen i bakgrunden",
@@ -42,6 +47,7 @@
 	"preferences": "Inställningar",
 	"general": "Allmänt",
 	"sideButtonLabels": "Visa sidoknappsetiketter",
+	"showModelFileNames": "Mina modeller: visa alltid hela modellfilens namn",
 	"colorThemeLabel": "Färgtema",
 	"complexityLevelLabel": "Användargränssnittets komplexitetsnivå",
 	"selectComplexityLevelPlaceholder": "Välj en standardkomplexitetsnivå för användargränssnittet",
@@ -53,17 +59,26 @@
 	"chat/highlightChatMessageOnHover": "Markera chattmeddelande vid hovring",
 	"chat/doubleClickMessageToEdit": "Dubbelklicka på ett chattmeddelande för att redigera",
 
+	"chat/aiNaming/label": "Chatt-AI-namngivning",
+	"chat/aiNaming/mode/label": "AI-genererade chattnamn",
+	"chat/aiNaming/mode/value/never": "Aldrig",
+	"chat/aiNaming/mode/value/never/subTitle": "Skapa inte AI-genererade chattnamn",
+	"chat/aiNaming/mode/value/auto": "Auto",
+	"chat/aiNaming/mode/value/auto/subTitle": "Avgör om namn ska skapas baserat på genereringshastighet",
+	"chat/aiNaming/mode/value/always": "Alltid",
+	"chat/aiNaming/mode/value/always/subTitle": "Skapa AI-genererade chattnamn oavsett genereringshastighet",
+	"chat/aiNaming/emoji": "Använd emojis i AI-genererade chattnamn",
 	"chat/keyboardShortcuts/label": "Tangentbordsgenvägar",
 	"chat/keyboardShortcuts/verbPrefix": "Använd",
 	"chat/keyboardShortcuts/regenerate": "för att regenerera det senaste meddelandet i chatten",
 	"chat/keyboardShortcuts/sendMessage": "för att skicka meddelande",
-	
+
 	"onboarding/blockTitle": "Introduktionshjälp",
 	"onboarding/dismissedHints": "Avfärdade introduktionshjälp",
 	"onboarding/resetHintTooltip": "Klicka för att återaktivera denna introduktionshjälp",
 	"onboarding/resetAllHints": "Återställ all introduktionshjälp",
 	"onboarding/noneDismissed": "Inga avfärdade hjälpmeddelanden, för närvarande visas alla introduktionshjälpmeddelanden tills de avfärdas",
-	
+
 	"firstTimeExperienceLabel": "Chatt första gången upplevelse",
 	"firstTimeExperienceMarkCompletedLabel": "Markera som slutförd",
 	"firstTimeExperienceResetLabel": "Återställ",
@@ -76,16 +91,17 @@
 	"languageLabel": "Språk",
 	"changeLanguageLabel": "Välj appens språk (fortfarande under utveckling)",
 	"developerLabel": "Utvecklare",
+	"localServiceLabel": "Lokal LLM-tjänst (utan gränssnitt)",
 	"showExperimentalFeaturesLabel": "Visa experimentella funktioner",
 	"appFirstLoadLabel": "Appens första laddningsupplevelse",
 	"showDebugInfoBlocksInChatLabel": "Visa felsökningsinformationsblock i chatten",
 	"autoLoadBundledLLMLabel": "Ladda automatiskt en bundlad LLM-modell vid start",
 	"showReleaseNotes": "Visa versionsanteckningar",
 	"hideReleaseNotes": "Dölj versionsanteckningar",
-	
+
 	"backendDownloadNewUpdate": "Nyare backends är tillgängliga!",
 	"backendDownloadNewUpdateAction": "Gå till utvecklarsidan",
-	
+
 	"backendDownloadChannel.label": "LM Studio Extension Packs nedladdningskanal",
 	"backendDownloadChannel.value.stable": "Stabil",
 	"backendDownloadChannel.value.beta": "Beta",
@@ -96,9 +112,10 @@
 	"appUpdateChannel.label": "LM Studio Uppdateringskanal",
 	"appUpdateChannel.value.stable": "Stabil",
 	"appUpdateChannel.value.beta": "Beta",
+	"appUpdateChannel.value.alpha": "Alpha",
 	"appUpdateChannel.shortLabel": "Appuppdateringskanal",
 	"appUpdateChannel.hint": "Välj kanalen från vilken du vill ta emot LM Studio-appuppdateringar. \"{{stableName}}\" är den rekommenderade kanalen för de flesta användare.",
-	
+
 	"modelLoadingGuardrails.label": "Modellinläsningsskydd",
 	"modelLoadingGuardrails.description": "Att ladda modeller bortom systemresursgränser kan orsaka systeminstabilitet eller frysning. Skyddsräcken förhindrar oavsiktlig överbelastning. Justera dessa gränser här om det behövs, men var medveten om att ladda modeller nära systemets gräns kan minska stabiliteten.",
 	"modelLoadingGuardrails.value.off": "AV (Ej rekommenderat)",
@@ -114,7 +131,7 @@
 	"modelLoadingGuardrails.value.high/subTitle": "Starka försiktighetsåtgärder mot systemöverbelastning",
 	"modelLoadingGuardrails.value.high/detail": "Strikt detalj",
 	"modelLoadingGuardrails.value.custom": "Anpassad",
-		"modelLoadingGuardrails.value.custom/subTitle": "Ställ in din egen gräns för maximal modellstorlek som kan laddas",
+	"modelLoadingGuardrails.value.custom/subTitle": "Ställ in din egen gräns för maximal modellstorlek som kan laddas",
 	"modelLoadingGuardrails.value.custom/detail": "Anpassad detalj",
 	"modelLoadingGuardrails.custom.label": "Minnesgräns: ",
 	"modelLoadingGuardrails.custom.unitGB": "GB",
@@ -122,13 +139,22 @@
 
 	"experimentalLoadPresets": "Aktivera stöd för modellinläsningskonfiguration i förinställningar",
 	"experimentalLoadPresets.description": "Om förinställningar ska tillåtas inkludera modellinläsningskonfigurationer. Denna funktion är experimentell och vi välkomnar feedback.",
-	
+
+	"unloadPreviousJITModelOnLoad": "JIT-modeller auto-avlastning: säkerställ att högst 1 modell är inläst via JIT samtidigt (avlastar föregående modell)",
+	"autoDeleteExtensionPacks": "Ta automatiskt bort minst nyligen använda Runtime Extension Packs",
+	"autoUpdateExtensionPacks": "Uppdatera valda Runtime Extension Packs automatiskt",
+	"useHFProxy.label": "Använd LM Studios Hugging Face-proxy",
+	"useHFProxy.hint": "Använd LM Studios Hugging Face-proxy för att söka och ladda ner modeller. Detta kan hjälpa användare som har problem att komma åt Hugging Face direkt.",
+	"separateReasoningContentInResponses": "Separera `reasoning_content` och `content` i API-svar när det är tillämpligt",
+	"separateReasoningContentInResponses/hint": "Denna inställning fungerar endast för 'reasoning'-modeller som DeepSeek R1, dess destillerade varianter och andra modeller som producerar CoT i `<think>` och `</think>`-taggar.",
+
 	"promptWhenCommittingUnsavedChangesWithNewFields": "Förinställningar: Visa bekräftelsedialog när nya fält läggs till i förinställningen",
 	"promptWhenCommittingUnsavedChangesWithNewFields.description": "Detta är användbart om du vill förhindra att nya fält oavsiktligt läggs till i förinställningar",
-	
-	"autoStartOnLogin": "Starta LLM-tjänst vid inloggning",
-	"autoStartOnLogin.description": "Starta automatiskt LLM-tjänsten när du loggar in på din dator",
-	
+
+	"enableLocalService": "Aktivera lokal LLM-tjänst",
+	"enableLocalService.subtitle": "Använd LM Studios LLM-server utan att behöva ha LM Studio-applikationen öppen",
+	"enableLocalService.description": "När detta är aktiverat startas LM Studios lokala LLM-tjänst automatiskt vid uppstart. Att stänga LM Studio lämnar även den lokala LLM-tjänsten igång i systemfältet.",
+
 	"expandConfigsOnClick": "Expandera konfigurationer vid klick istället för vid hovring",
 
 	"migrateChats": {
@@ -155,5 +181,15 @@
 		"hasBetterFooterCardText": "Vi har förbättrat chattmigreringen sedan du migrerade dina gamla chattar. Du kan köra migrationsprocessen igen. (Vi kommer att skapa en ny mapp för att innehålla de nyss migrerade chattarna.)",
 		"dismissConfirm": "Avfärda",
 		"dismissConfirmDescription": "Du kan alltid hantera chattmigrering i Inställningar"
+	},
+	"toolConfirmation": {
+		"label": "Verktygsbekräftelse",
+		"neverAsk": {
+			"label": "Fråga aldrig om bekräftelse innan ett verktyg körs (REKOMMENDERAS INTE)",
+			"hint": "Inaktivera bekräftelser innan ett verktyg körs. Detta rekommenderas inte.",
+			"warnTitle": "Är du säker?",
+			"warnDescription": "Att inaktivera bekräftelser för verktygsanrop är farligt. Om någon av dina plugins har bidragit med ett verktyg som kan utföra destruktiva åtgärder (såsom att köra ett kommando, ta bort filer, skriva över filer, ladda upp filer, etc), kommer modellen att kunna göra detta utan någon bekräftelse. Du kan alltid inaktivera bekräftelser för enskilda verktyg eller till och med per plugin. Att aktivera detta alternativ rekommenderas INTE. Var försiktig.",
+			"warnButton": "Jag förstår riskerna"
+		}
 	}
 }

--- a/sv/shared.json
+++ b/sv/shared.json
@@ -1,5 +1,271 @@
 {
   "copyLmStudioLinkButton/toolTip": "Kopiera modellens nedladdningslänk",
 
-  "filter.noMatches": "Inga träffar"
+  "filter.noMatches": "Inga träffar",
+  "longRunningTask": {
+    "unbundlingDependencies": {
+      "badge": "Extraherar resurser"
+    },
+    "performingBackendHardwareSurvey": {
+      "badge": "Kontrollerar körningskompatibilitet"
+    },
+    "indexingRuntimes": {
+      "badge": "Indexerar körningar"
+    },
+    "indexingModels": {
+      "badge": "Indexerar modeller"
+    },
+    "authenticating": {
+      "badge": "Autentiserar"
+    },
+    "autoUpdatingExtensionPack": {
+      "badge": "Uppdaterar tilläggspaket ({{name}} v{{version}})"
+    }
+  },
+  "auth": {
+    "prompt": "Logga in på LM Studio Hub",
+    "authError": "Autentisering misslyckades",
+    "noAccount": "Har du inget konto?",
+    "signUp": "Registrera dig",
+    "havingTrouble": "Har du problem?",
+    "retry": "Försök igen"
+  },
+  "artifacts": {
+    "fetchError": "Kunde inte hämta artefakter",
+    "organizationVisible": "Synlig för organisationen"
+  },
+
+  "incompatible": "Inkompatibel",
+  "compatible": "Kompatibel",
+  "public": "Offentlig",
+  "private": "Privat",
+  "yes": "Ja",
+  "no": "Nej",
+  "go": "Gå",
+  "proceedWithEllipsis": "Fortsätt...",
+  "proceed": "Fortsätt",
+  "inProgress": "Pågår...",
+  "failed": "Misslyckades",
+  "pending": "Väntar",
+  "doneWithExclamation": "Klar!",
+  "done": "Klar",
+  "complete": {
+    "completeWithEllipsis": "Slutför...",
+    "complete": "Slutför",
+    "completingWithEllipsis": "Slutför...",
+    "completing": "Slutför",
+    "completedWithExclamation": "Slutfört!",
+    "completed": "Slutfört"
+  },
+  "cancel": {
+    "cancelWithEllipsis": "Avbryt...",
+    "cancel": "Avbryt",
+    "cancelingWithEllipsis": "Avbryter...",
+    "canceling": "Avbryter",
+    "canceled": "Avbruten"
+  },
+  "next": {
+    "nextWithEllipsis": "Nästa...",
+    "next": "Nästa"
+  },
+  "back": {
+    "backWithEllipsis": "Tillbaka...",
+    "back": "Tillbaka"
+  },
+  "close": {
+    "closeWithEllipsis": "Stäng...",
+    "close": "Stäng",
+    "closingWithEllipsis": "Stänger...",
+    "closing": "Stänger",
+    "closedWithExclamation": "Stängd!",
+    "closed": "Stängd"
+  },
+  "delete": {
+    "deleteWithEllipsis": "Ta bort...",
+    "delete": "Ta bort",
+    "deletingWithEllipsis": "Tar bort...",
+    "deleting": "Tar bort",
+    "deletedWithExclamation": "Borttagen!",
+    "deleted": "Borttagen"
+  },
+  "retry": {
+    "retryWithEllipsis": "Försök igen...",
+    "retry": "Försök igen",
+    "retryingWithEllipsis": "Försöker igen...",
+    "retrying": "Försöker igen"
+  },
+  "refresh": {
+    "refreshWithEllipsis": "Uppdatera...",
+    "refresh": "Uppdatera",
+    "refreshingWithEllipsis": "Uppdaterar...",
+    "refreshing": "Uppdaterar",
+    "refreshedWithExclamation": "Uppdaterad!",
+    "refreshed": "Uppdaterad"
+  },
+  "confirm": {
+    "confirm": "Bekräfta",
+    "confirmingWithEllipsis": "Bekräftar...",
+    "confirming": "Bekräftar",
+    "confirmedWithExclamation": "Bekräftad!",
+    "confirmed": "Bekräftad"
+  },
+  "copy": {
+    "copyWithEllipsis": "Kopiera...",
+    "copy": "Kopiera",
+    "copyingWithEllipsis": "Kopierar...",
+    "copying": "Kopierar",
+    "copiedWithExclamation": "Kopierad!",
+    "copied": "Kopierad"
+  },
+  "edit": {
+    "editWithEllipsis": "Redigera...",
+    "edit": "Redigera",
+    "editingWithEllipsis": "Redigerar...",
+    "editing": "Redigerar",
+    "editedWithExclamation": "Redigerad!",
+    "edited": "Redigerad"
+  },
+  "load": {
+    "loadWithEllipsis": "Ladda...",
+    "load": "Ladda",
+    "loadingWithEllipsis": "Laddar...",
+    "loading": "Laddar",
+    "loadedWithExclamation": "Laddad!",
+    "loaded": "Laddad"
+  },
+  "save": {
+    "saveWithEllipsis": "Spara...",
+    "save": "Spara",
+    "savingWithEllipsis": "Sparar...",
+    "saving": "Sparar",
+    "savedWithExclamation": "Sparad!",
+    "saved": "Sparad"
+  },
+  "saveAs": {
+    "saveAsWithEllipsis": "Spara som...",
+    "saveAs": "Spara som"
+  },
+  "saveAsNew": {
+    "saveAsNewWithEllipsis": "Spara som ny...",
+    "saveAsNew": "Spara som ny"
+  },
+  "search": {
+    "searchWithEllipsis": "Sök...",
+    "search": "Sök",
+    "searchingWithEllipsis": "Söker...",
+    "searching": "Söker"
+  },
+  "update": {
+    "updateWithEllipsis": "Uppdatera...",
+    "update": "Uppdatera",
+    "updatingWithEllipsis": "Uppdaterar...",
+    "updating": "Uppdaterar",
+    "updatedWithExclamation": "Uppdaterad!",
+    "updated": "Uppdaterad"
+  },
+  "create": {
+    "createWithEllipsis": "Skapa...",
+    "create": "Skapa",
+    "creatingWithEllipsis": "Skapar...",
+    "creating": "Skapar",
+    "createdWithExclamation": "Skapad!",
+    "created": "Skapad"
+  },
+  "reset": {
+    "resetWithEllipsis": "Återställ...",
+    "reset": "Återställ",
+    "resettingWithEllipsis": "Återställer...",
+    "resetting": "Återställer"
+  },
+  "pause": {
+    "pause": "Pausa",
+    "pausingWithEllipsis": "Pausar...",
+    "pausing": "Pausar",
+    "paused": "Pausad"
+  },
+  "download": {
+    "download": "Ladda ner",
+    "downloadingWithEllipsis": "Laddar ner...",
+    "downloading": "Laddar ner",
+    "downloadedWithExclamation": "Nerladdad!",
+    "downloaded": "Nerladdad"
+  },
+  "upload": {
+    "uploadWithEllipsis": "Ladda upp...",
+    "upload": "Ladda upp",
+    "uploadingWithEllipsis": "Laddar upp...",
+    "uploading": "Laddar upp",
+    "uploadedWithExclamation": "Uppladdad!",
+    "uploaded": "Uppladdad"
+  },
+  "remove": {
+    "removeWithEllipsis": "Ta bort...",
+    "remove": "Ta bort",
+    "removingWithEllipsis": "Tar bort...",
+    "removing": "Tar bort",
+    "removedWithExclamation": "Borttagen!",
+    "removed": "Borttagen"
+  },
+  "uninstall": {
+    "uninstallWithEllipsis": "Avinstallera...",
+    "uninstall": "Avinstallera",
+    "uninstallingWithEllipsis": "Avinstallerar...",
+    "uninstalling": "Avinstallerar",
+    "uninstalledWithExclamation": "Avinstallerad!",
+    "uninstalled": "Avinstallerad"
+  },
+  "resume": {
+    "resumeWithEllipsis": "Återuppta...",
+    "resume": "Återuppta",
+    "resumingWithEllipsis": "Återupptar...",
+    "resuming": "Återupptar"
+  },
+  "start": {
+    "startWithEllipsis": "Starta...",
+    "start": "Starta",
+    "startingWithEllipsis": "Startar...",
+    "starting": "Startar",
+    "started": "Startad"
+  },
+  "stop": {
+    "stopWithEllipsis": "Stoppa...",
+    "stop": "Stoppa",
+    "stoppingWithEllipsis": "Stoppar...",
+    "stopping": "Stoppar",
+    "stoppedWithExclamation": "Stoppad!",
+    "stopped": "Stoppad"
+  },
+  "import": {
+    "importWithEllipsis": "Importera...",
+    "import": "Importera",
+    "importingWithEllipsis": "Importerar...",
+    "importing": "Importerar",
+    "importedWithExclamation": "Importerad!",
+    "imported": "Importerad"
+  },
+  "letsGo": {
+    "letsGo": "Kör igång",
+    "letsGoWithEllipsis": "Kör igång...",
+    "letsGoWithExclamation": "Kör igång!"
+  },
+  "run": {
+    "runWithEllipsis": "Kör...",
+    "run": "Kör",
+    "runningWithEllipsis": "Kör...",
+    "running": "Kör"
+  },
+  "configure": {
+    "configureWithEllipsis": "Konfigurera...",
+    "configure": "Konfigurera",
+    "configuringWithEllipsis": "Konfigurerar...",
+    "configured": "Konfigurerad"
+  },
+  "publish": {
+    "publishWithEllipsis": "Publicera...",
+    "publish": "Publicera",
+    "publishingWithEllipsis": "Publicerar...",
+    "publishing": "Publicerar",
+    "publishedWithExclamation": "Publicerad!",
+    "published": "Publicerad"
+  }
 }


### PR DESCRIPTION
Updated all Swedish (sv) localization files by adding all the new strings from the en/ folder files and then translated them.