### PR TITLE
Edit system prompt, duplicate and clear all

### DIFF
--- a/en/chat.json
+++ b/en/chat.json
@@ -155,8 +155,8 @@
     }
   },
 
-  "topBarActions/duplicateChat": "Duplicate",
-  "topBarActions/clearChat": "Clear All",
+  "topBarActions/duplicateChat": "Duplicate chat",
+  "topBarActions/clearChat": "Clear all messages...",
   "topBarActions/clearChatConfirmation": "Are you sure you want to clear all messages in this chat?",
   "topBarActions/clearChatCancel": "Cancel",
   "topBarActions/clearChatDelete": "Clear All",

--- a/en/config.json
+++ b/en/config.json
@@ -41,6 +41,7 @@
   "llm.prediction.systemPrompt/openEditor": "Editor",
   "llm.prediction.systemPrompt/closeEditor": "Close Editor",
   "llm.prediction.systemPrompt/openedEditor": "Opened in Editor...",
+  "llm.prediction.systemPrompt/edit": "Edit System Prompt...",
   "llm.prediction.temperature/title": "Temperature",
   "llm.prediction.temperature/subTitle": "How much randomness to introduce. 0 will yield the same result every time, while higher values will increase creativity and variance",
   "llm.prediction.temperature/info": "From llama.cpp help docs: \"The default value is <{{dynamicValue}}>, which provides a balance between randomness and determinism. At the extreme, a temperature of 0 will always pick the most likely next token, leading to identical outputs in each run\"",


### PR DESCRIPTION
Now that we have more horizontal space to work with, we can be more clear about what these buttons do