### PR TITLE
Update zh-CN strings for latest LM Studio keys

### DIFF
--- a/zh-CN/chat.json
+++ b/zh-CN/chat.json
@@ -23,12 +23,10 @@
   "noChatSelectedPlaceholder": "请选择一个聊天",
   "unnamedChat": "未命名聊天",
   "emptyFolder": "文件夹为空",
-
   "tokenCount": "token数",
   "messageTokenCount": "输入token数",
   "tokenCount/hint": "消息中的token数量。使用当前选定模型的分词器计算。\n\n需要加载模型。",
   "messageTokenCount/hint": "消息中的token数量。使用当前选定模型的分词器计算。\n\n**不包括**附件中的token估计值。",
-
   "notes": "对话笔记",
   "notes/add/first": "添加笔记",
   "notes/add/another": "再加一条笔记",
@@ -37,7 +35,6 @@
   "notes/delete": "删除笔记",
   "notes/noteLabel": "笔记",
   "notes/copyContent": "复制笔记内容",
-
   "actions/sendMessage/error": "发送消息失败",
   "actions/loadModel/error": "🥲 加载模型失败",
   "actions/addFile": "[实验性] 将文件附加到此消息\n(.pdf, 纯文本, 或 .docx)",
@@ -91,10 +88,8 @@
   "actions/createFolderAtRoot/error": "在根目录创建文件夹失败",
   "actions/openInFolder/mac": "在 Finder 中显示",
   "actions/openInFolder/pc": "在文件资源管理器中显示",
-
   "actions/createChat/error": "创建聊天失败",
   "actions/deleteChat/errorTitle": "删除聊天失败",
-
   "userFile/fileSizeLimit": "文件大小限制为",
   "userFile/noImageSupport": "模型不支持图片输入",
   "userFile/errorPrefix": "错误 - ",
@@ -109,42 +104,32 @@
   "errorTitle": "错误",
   "userFile/chatTerminalDocumentsCount_one": "对话中有 {{count}} 个文档",
   "userFile/chatTerminalDocumentsCount_other": "对话中有 {{count}} 个文档",
-
   "prediction/busyModel/title": "模型忙碌中",
   "prediction/busyModel/message": "请等待模型完成后再试",
   "prediction/noModel/title": "未选择模型",
   "prediction/modelLoading": "消息已排队，将在模型加载完成后发送",
   "prediction/noModel/message": "选择一个模型以发送消息",
   "prediction/unloadModel/error": "卸载模型失败",
-
   "retrieval/user/processingLabel": "AI 正在思考...",
   "retrieval/powerUser/intermediateStepsHidden": "中间步骤已隐藏。点击以展开。",
   "retrieval/actions/clickToExpand": "点击以展开中间步骤",
   "retrieval/actions/clickToCollapse": "点击以折叠中间步骤",
-
   "style": "聊天外观",
-
   "style/viewMode/markdown": "Markdown",
   "style/viewMode/plaintext": "纯文本",
   "style/viewMode/monospace": "等宽字体",
-
   "speculativeDecodingVisualization/toggle": "可视化已采纳的草稿token",
   "speculativeDecodingVisualization/fromDraftModel_one": "已采纳的草稿token",
   "speculativeDecodingVisualization/fromDraftModel_other": "已采纳的草稿token",
   "speculativeDecodingVisualization/cannotChangeViewMode": "可视化草稿token时无法切换显示模式。",
-
   "style/fontSize/label": "字体大小",
   "style/fontSize/medium": "默认",
   "style/fontSize/large": "大",
   "style/fontSize/small": "小",
-
   "style/debugBlocks/label": "显示调试信息块",
-
   "style/thinkingUI/label": "默认展开推理块",
   "style/chatFullWidth/label": "聊天容器宽度适应窗口",
-
   "style/chatUtilityMenusShowLabel/label": "显示聊天实用工具菜单",
-
   "messageBlocks": {
     "expandBlockTooltip": "展开内容",
     "collapseBlockTooltip": "收起内容",
@@ -154,20 +139,16 @@
       "expandTooltip": "展开调试信息块"
     }
   },
-  
   "chatTabOptions/clearAllMessages": "清空所有聊天记录...",
   "chatTabOptions/duplicateChat": "复制聊天",
-
   "topBarActions/duplicateChat": "复制聊天",
   "topBarActions/clearChat": "清除所有消息",
   "topBarActions/clearChatConfirmation": "您确定要清除此聊天中的所有消息吗？",
   "topBarActions/clearChatCancel": "取消",
   "topBarActions/clearChatDelete": "全部清除",
-  
   "noModels.indexing": "正在索引模型文件...（这可能需要一段时间）",
   "noModels.downloading": "正在下载您的第一个LLM...",
   "noModels": "还没有LLM！下载一个开始吧！",
-  
   "plugins": {
     "pluginTrigger": {
       "noPlugins": "插件",
@@ -192,7 +173,9 @@
       },
       "startRunningDevelopmentPlugin/error": "开发模式插件启动失败",
       "stopRunningDevelopmentPlugin/error": "开发模式插件停止失败",
-      "forceReInitPlugin/error": "重启插件失败"
+      "forceReInitPlugin/error": "重启插件失败",
+      "signOutMcpPlugin/error": "退出插件登录失败",
+      "cancelMcpAuthentication/error": "取消插件身份验证失败"
     },
     "pluginConfiguration": {
       "title": "插件配置",
@@ -222,7 +205,6 @@
     },
     "restartErrorPlugin/error": "重启插件失败"
   },
-
   "genInfo": {
     "tokensPerSecond": "{{tokensPerSecond}} token/s",
     "predictedTokensCount": "{{predictedTokensCount}} token",
@@ -237,10 +219,13 @@
     "stopReason.maxPredictedTokensReached": "达到最大预测词元",
     "stopReason.contextLengthReached": "达到上下文长度上限",
     "speculativeDecodedBy": "草稿模型：{{decodedBy}}",
-    "speculativeDecodingStats": "已采纳 {{accepted}}/{{total}} 个草稿token（{{percentage}}%）"
+    "speculativeDecodingStats": "已采纳 {{accepted}}/{{total}} 个草稿token（{{percentage}}%）",
+    "speculativeDecodingAcceptedPercentage": "已采纳 {{percentage}}% 的草稿token",
+    "speculativeDecodingTooltip": "已采纳 {{accepted}}/{{total}} 个草稿token"
   },
-
   "tabs": {
     "systemPromptEditorTab.headerLabel": "编辑系统提示词"
-  }
+  },
+  "actions/clearLastUsedModel": "清除上次使用的模型",
+  "actions/clearLastUsedModel/error": "清除上次使用的模型失败。"
 }

--- a/zh-CN/config.json
+++ b/zh-CN/config.json
@@ -34,7 +34,6 @@
     "promptTemplate/title": "提示词模板",
     "customFields/title": "自定义字段"
   },
-
   "llm.prediction.systemPrompt/title": "系统提示",
   "llm.prediction.systemPrompt/description": "使用此字段向模型提供背景指令,如一套规则、约束或一般要求。",
   "llm.prediction.systemPrompt/subTitle": "AI 指南",
@@ -117,7 +116,6 @@
   "llm.prediction.speculativeDecoding.draftModel/title": "草稿模型",
   "llm.prediction.reasoning.parsing/title": "推理过程解析方式",
   "llm.prediction.reasoning.parsing/subTitle": "控制模型输出中推理过程的解析方式",
-
   "llm.load.mainGpu/title": "主 GPU",
   "llm.load.mainGpu/subTitle": "用于模型计算的 GPU 优先级",
   "llm.load.mainGpu/placeholder": "选择主 GPU...",
@@ -131,7 +129,6 @@
   "load.gpuStrictVramCap.customSubTitleOn": "开启：系统将限制模型权重的卸载仅限于专用 GPU 内存及 RAM 。上下文仍可能使用共享内存",
   "load.gpuStrictVramCap.customGpuOffloadWarning": "模型的卸载仅限于专用 GPU 内存。实际卸载的层数可能会有所不同",
   "load.allGpusDisabledWarning": "所有 GPU 目前均被禁用。请启用至少一个以进行卸载",
-
   "llm.load.contextLength/title": "上下文长度",
   "llm.load.contextLength/subTitle": "模型可以一次性关注的token最大数量。请参阅“推理参数”下的“对话溢出”选项以获取更多管理方式",
   "llm.load.contextLength/info": "指定模型一次可以考虑的最大token数量，影响其处理过程中保留的上下文量",
@@ -139,7 +136,6 @@
   "llm.load.seed/title": "种子",
   "llm.load.seed/subTitle": "用于文本生成的随机数生成器的种子。-1 表示随机",
   "llm.load.seed/info": "随机种子：设置随机数生成的种子以确保可重复的结果",
-
   "llm.load.llama.evalBatchSize/title": "评估批处理大小",
   "llm.load.llama.evalBatchSize/subTitle": "每次处理的输入token数量。增加此值会提高性能，但会增加内存使用量",
   "llm.load.llama.evalBatchSize/info": "设置评估期间一起处理的示例数量,影响速度和内存使用",
@@ -198,7 +194,6 @@
   "llm.load.mlx.kvCacheQuantization/groupSize/tooltip": "高级：量化乘法的分组大小配置\n\n• 高精度 = 分组 32\n• 均衡 = 分组 64\n• 极速 = 分组 128\n",
   "llm.load.mlx.kvCacheQuantization/quantizedStart/title": "达到此上下文长度后开始量化",
   "llm.load.mlx.kvCacheQuantization/quantizedStart/tooltip": "当上下文长度达到该值时，开始对 KV 缓存进行量化",
-
   "embedding.load.contextLength/title": "上下文长度",
   "embedding.load.contextLength/subTitle": "模型可以一次性关注的token最大数量。请参阅“推理参数”下的“对话溢出”选项以获取更多管理方式",
   "embedding.load.contextLength/info": "指定模型一次可以考虑的最大token数量，影响其处理过程中保留的上下文量",
@@ -222,9 +217,7 @@
   "embedding.load.llama.tryMmap/info": "直接从磁盘加载模型文件到内存",
   "embedding.load.seed/title": "种子",
   "embedding.load.seed/subTitle": "用于文本生成的随机数生成器的种子。-1 表示随机种子",
-
   "embedding.load.seed/info": "随机种子：设置随机数生成的种子以确保可重复的结果",
-
   "presetTooltip": {
     "included/title": "预设值",
     "included/description": "以下字段将会被应用",
@@ -245,7 +238,6 @@
     "hubLabel": "来自 {{user}} 的 Hub 预设",
     "ownHubLabel": "您的 Hub 预设"
   },
-
   "customInputs": {
     "string": {
       "emptyParagraph": "<空>"
@@ -369,7 +361,6 @@
   "idleTTL.label": "空闲时自动卸载",
   "idleTTL.hint": "如设置，模型在空闲指定时间后将自动卸载。",
   "idleTTL.mins": "分钟",
-
   "presets": {
     "title": "预设",
     "commitChanges": "提交更改",
@@ -545,21 +536,29 @@
     },
     "inclusiveness": {
       "speculativeDecoding": "包含在预设中"
-    }
+    },
+    "saveChanges": "保存",
+    "saveChanges/description": "将你的更改保存到预设。",
+    "saveChanges.manual": "检测到新字段。你可以选择将哪些更改包含到预设中。",
+    "saveChanges.manual.hold.0": "按住",
+    "saveChanges.manual.hold.1": "以选择要保存到预设的更改。",
+    "saveChanges.saveAll.hold.0": "按住",
+    "saveChanges.saveAll.hold.1": "以保存全部更改。",
+    "saveChanges.saveInPreset.hold.0": "按住",
+    "saveChanges.saveInPreset.hold.1": "仅保存已包含在预设中的字段更改。",
+    "saveChanges/error": "将更改保存到预设失败。",
+    "saveChanges.manual/description": "选择要包含到预设中的更改。",
+    "cannotSaveChangesNoChanges": "没有可保存的更改。"
   },
-
   "flashAttentionWarning": "Flash Attention 是一项实验性功能,可能会导致某些模型出现问题。如果您遇到问题,请尝试禁用它。",
   "llamaKvCacheQuantizationWarning": "KV 缓存量化是一项实验性功能，可能会导致某些模型出现问题。V 缓存量化必须启用 Flash Attention。如果遇到问题，请将默认值重置为\"F16\"。",
-
   "seedUncheckedHint": "随机种子",
   "ropeFrequencyBaseUncheckedHint": "自动",
   "ropeFrequencyScaleUncheckedHint": "自动",
-
   "hardware": {
     "environmentVariables": "环境变量",
     "environmentVariables.info": "如果不确定,请保留默认值",
     "environmentVariables.reset": "重置为默认值",
-    
     "gpus.information": "配置检测到的图形处理单元 (GPU）",
     "gpuSettings": {
       "editMaxCapacity": "编辑最大容量",
@@ -590,7 +589,6 @@
       "toggleGpu": "启用/禁用 GPU"
     }
   },
-
   "load.gpuSplitConfig/title": "GPU 分配配置",
   "envVars/title": "设置环境变量",
   "envVars": {
@@ -610,5 +608,12 @@
     "values": {
       "title": "当前值"
     }
-  }
+  },
+  "llm.load.numCpuExpertLayersRatio/title": "强制将 MoE 权重放在 CPU 的层数",
+  "llm.load.numCpuExpertLayersRatio/subTitle": "强制将专家层放在 CPU 的层数。可节省显存，且有时比部分 GPU 卸载更快。若模型可完全装入显存，不建议启用。",
+  "llm.load.numCpuExpertLayersRatio/info": "指定强制将专家层放在 CPU 的层数。注意力层仍留在 GPU，在节省显存的同时保持较快推理。",
+  "llm.load.numParallelSessions/title": "最大并发预测数",
+  "llm.load.numParallelSessions/subTitle": "模型可同时运行的最大预测数。并发越高，单次预测速度可能下降，但开始更快，整体吞吐量更高",
+  "llm.load.useUnifiedKvCache/title": "统一 KV 缓存",
+  "llm.load.useUnifiedKvCache/subTitle": "控制并发预测是否共享同一个 KV 缓存以节省内存。关闭后每次预测都可使用完整上下文长度，但会占用更多内存"
 }

--- a/zh-CN/developer.json
+++ b/zh-CN/developer.json
@@ -3,9 +3,7 @@
   "tabs/extensions": "LM 运行环境",
   "loadSettings/title": "加载设置",
   "modelSettings/placeholder": "选择一个模型进行配置",
-
   "loadedModels/noModels": "没有已加载的模型",
-
   "serverOptions/title": "服务器选项",
   "serverOptions/configurableTitle": "可配置选项",
   "serverOptions/port/hint": "设置本地服务器将使用的网络端口。默认情况下，LM Studio 使用端口 1234。如果该端口已被占用，您可能需要更改此设置。",
@@ -47,24 +45,20 @@
   "serverOptions/jitModelLoadingTTL/ttl/unit": "分钟",
   "serverOptions/unloadPreviousJITModelOnLoad/title": "仅保留最后一个即时加载的模型",
   "serverOptions/unloadPreviousJITModelOnLoad/hint": "确保在任意时刻最多只有一个即时加载的模型（会卸载之前的模型）",
-
   "serverLogs/scrollToBottom": "跳转到底部",
   "serverLogs/clearLogs": "清除日志 ({{shortcut}})",
   "serverLogs/openLogsFolder": "打开服务器日志文件夹",
-
   "runtimeSettings/title": "运行环境设置",
   "runtimeSettings/chooseRuntime/title": "配置运行环境",
   "runtimeSettings/chooseRuntime/description": "为每个模型格式选择一个运行环境",
   "runtimeSettings/chooseRuntime/showAllVersions/label": "显示所有运行环境",
   "runtimeSettings/chooseRuntime/showAllVersions/hint": "默认情况下，LM Studio 只显示每个兼容运行环境的最新版本。启用此选项可以查看所有可用的运行环境。",
   "runtimeSettings/chooseRuntime/select/placeholder": "选择一个运行环境",
-
   "runtimeSettings/chooseFrameworks/title": "框架",
   "runtimeSettings/chooseFrameworks/description": "为每个功能选择要使用的框架",
   "runtimeSettings/chooseFramework/documentParser/builtIn/label": "内置解析器",
   "runtimeSettings/chooseFramework/documentParser/select/label": "文档解析器",
   "runtimeSettings/chooseFramework/documentParser/select/placeholder": "请选择文档解析器",
-
   "runtimeOptions/uninstall": "卸载",
   "runtimeOptions/uninstallDialog/title": "卸载 {{runtimeName}}？",
   "runtimeOptions/uninstallDialog/body": "卸载此运行环境将从系统中移除它。此操作不可逆。",
@@ -75,7 +69,6 @@
   "runtimeOptions/noCompatibleRuntimes": "未找到兼容的运行环境",
   "runtimeOptions/downloadIncompatibleRuntime": "此运行环境被认为与您的机器不兼容。它很可能无法正常工作。",
   "runtimeOptions/noRuntimes": "未找到运行环境",
-
   "runtimes": {
     "manageLMRuntimes": "管理 LM 运行环境",
     "includeOlderRuntimeVersions": "包含旧版本",
@@ -127,9 +120,7 @@
       "noFrameworks": "未安装框架"
     }
   },
-
   "inferenceParams/noParams": "此模型类型无可用配置的推理参数",
-
   "quickDocs": {
     "tabChipTitle": "快速文档",
     "newToolUsePopover": "代码片段现已在“快速文档”中提供。点击此处开始使用工具！",
@@ -160,20 +151,33 @@
     },
     "newBadge": "新功能"
   },
-
   "endpoints/openaiCompatRest/title": "支持的端点 (与 OpenAI 兼容的格式)",
   "endpoints/openaiCompatRest/getModels": "列出当前已加载的模型",
   "endpoints/openaiCompatRest/postCompletions": "文本补全模式。给定一个提示，预测下一个token。注意：OpenAI 认为此端点已'弃用'。",
   "endpoints/openaiCompatRest/postChatCompletions": "聊天补全。向模型发送聊天历史以预测下一个助手响应。",
   "endpoints/openaiCompatRest/postEmbeddings": "文本嵌入。为给定的文本输入生成文本嵌入。接受字符串或字符串数组。",
-
   "model.createVirtualModelFromInstance": "另存为新的虚拟模型",
   "model.createVirtualModelFromInstance/error": "另存为新的虚拟模型失败",
-
   "model": {
     "toolUseSectionTitle": "工具使用",
     "toolUseDescription": "检测到此模型经过工具使用的训练\n\n打开<custom-link>快速文档</custom-link>以了解更多信息。"
   },
-
-  "apiConfigOptions/title": "API 配置"
+  "apiConfigOptions/title": "API 配置",
+  "serverOptions/allowMcp/title": "允许远程 MCP",
+  "serverOptions/allowMcp/hint": "允许使用未在你的 mcp.json 中配置的 MCP。这些 MCP 连接为临时连接，仅在请求期间存在。目前仅支持远程 MCP。",
+  "serverOptions/allowMcp/mode/off": "关闭",
+  "serverOptions/allowMcp/mode/off/hint": "不允许服务器请求使用 MCP",
+  "serverOptions/allowMcp/mode/remote": "远程",
+  "serverOptions/allowMcp/mode/remote/hint": "允许连接到远程 MCP 服务器",
+  "serverOptions/start/error": "启动服务器失败",
+  "serverOptions/stop/error": "停止服务器失败",
+  "endpoints/openaiCompatRest/segmentedLabel": "类 OpenAI",
+  "endpoints/openaiCompatRest/postResponses": "用于生成模型响应的高级接口。可将上一条 response 的 id 作为下一次输入，实现有状态交互。",
+  "endpoints/lmStudioRest/segmentedLabel": "LM Studio",
+  "endpoints/lmStudioRestV1/getModels": "列出可用模型",
+  "endpoints/lmStudioRestV1/postModelsLoad": "按选项加载模型",
+  "endpoints/lmStudioRestV1/postModelsDownload": "下载模型",
+  "endpoints/lmStudioRestV1/postChat": "与模型聊天。支持有状态多轮对话和 MCP",
+  "endpoints/lmStudioRestV1/getModelsDownloadStatus": "获取模型下载状态",
+  "endpoints/anthropicCompatRest/segmentedLabel": "兼容 Anthropic"
 }

--- a/zh-CN/models.json
+++ b/zh-CN/models.json
@@ -3,12 +3,10 @@
   "filterModels.placeholder": "筛选模型...",
   "aggregate_one": "您有 {{count}} 个本地模型，占用了 {{size}} 的磁盘空间。",
   "aggregate_other": "您有 {{count}} 个本地模型，占用了 {{size}} 的磁盘空间。",
-
   "noModels.title": "您的本地 LLM 将显示在这里。",
   "noModels.discoverButtonText.prefix": "点击左侧边栏的",
   "noModels.discoverButtonText.suffix": "按钮来发现有趣的 LLM。",
   "noModels.discoverModelsPrompt": "去探索一些本地 LLM 吧！",
-
   "modelsTable.arch/label": "架构",
   "modelsTable.params/label": "参数量",
   "modelsTable.publisher/label": "发布者",
@@ -17,18 +15,15 @@
   "modelsTable.size/label": "尺寸",
   "modelsTable.dateModified/label": "修改日期",
   "modelsTable.actions/label": "操作",
-
   "modelsTable.quant/label": "量化规格",
   "modelsTable.llms/label": "语言模型",
   "modelsTable.embeddingModels/label": "嵌入模型",
-
   "action.model.delete": "删除",
   "action.model.delete.full": "删除模型",
   "action.model.delete.confirmation/title": "删除 {{name}}",
   "action.model.delete.confirmation/description": "您确定吗？这将永久删除与此模型相关的所有文件，此操作不可逆。",
   "action.model.delete.confirmation/confirm": "删除",
   "action.model.delete/error": "删除模型失败",
-
   "loader.model.bundled": "捆绑",
   "action.cancel": "取消",
   "indexingOngoing": "正在索引模型... 这可能需要几秒钟",
@@ -46,7 +41,6 @@
   "unresolvedVirtualModels.revealInExplorer": "在文件资源管理器中显示",
   "unresolvedVirtualModels.revealInFinder": "在 Finder 中显示",
   "unresolvedVirtualModels.reveal/error": "显示失败",
-
   "modelsDirectory": "模型目录",
   "modelsDirectory.change": "更改...",
   "modelsDirectory.change/error": "修改模型路径失败",
@@ -67,7 +61,7 @@
   "contextMenu/unpin": "取消固定",
   "contextMenu/copyAbsolutePath": "复制绝对路径",
   "contextMenu/copyModelName": "复制模型路径",
- "contextMenu/copyModelDefaultIdentifier": "复制默认标识符",
+  "contextMenu/copyModelDefaultIdentifier": "复制默认标识符",
   "contextMenu/showRawMetadata": "查看原始元数据",
   "contextMenu/openOnHuggingFace": "在 Hugging Face 上打开",
   "contextMenu": {
@@ -85,17 +79,14 @@
   "tooltip/editModelDefaultConfig/override": "编辑模型默认配置（*当前有覆盖）",
   "tooltip/visionBadge": "此模型支持图像输入",
   "tooltip/toolUseBadge": "此模型经过工具使用的训练",
-
   "visionBadge/label": "此模型支持图像输入",
   "toolUseBadge/label": "此模型经过工具使用的训练",
-
   "loader.action.load": "加载模型",
   "loader.action.clearChanges": "清除更改",
   "loader.action.cancel": "取消",
   "loader.info.clickOnModelToLoad": "点击模型以加载",
   "loader.info.configureLoadParameters": "配置模型加载参数",
   "loader.info.activeGeneratorWarning": "您正在使用带有自定义生成器的插件。当前加载的模型是否适用于该插件，取决于生成器的具体实现方式",
-
   "virtual": {
     "local": {
       "create": "创建虚拟模型",
@@ -110,6 +101,23 @@
       "next": "下一步",
       "confirm": "创建",
       "error": "创建虚拟模型失败"
+    },
+    "altsSelect": {
+      "title": "切换模型来源",
+      "resetButton": "重置为默认",
+      "description": "该模型有多个可用来源文件。",
+      "trigger": "变体"
     }
-  }
+  },
+  "indexingPageLoaderText": "正在索引模型...",
+  "loader.guardrails.estimatedMemoryUsage": "预计内存占用",
+  "loader.guardrails.total": "总计",
+  "loader.guardrails.gpu": "GPU",
+  "loader.guardrails.unavailable": "该模型无法估算内存占用",
+  "loader.guardrails.notEnoughResources": "当前设置下资源不足，无法加载该模型",
+  "loader.guardrails.notEnoughResources/options": "可选方案",
+  "loader.guardrails.notEnoughResources.moreInfoSection.appearsNotEnoughMemory": "看起来你的系统内存不足以加载此模型。",
+  "loader.guardrails.notEnoughResources.moreInfoSection.ifYouBelieveThisIsIncorrect": "如果你认为估算不准确，可在设置中调整模型加载保护，或按住 <altOptionKey /> 仍然加载。",
+  "loader.guardrails.notEnoughResources.moreInfoSection.warning": "加载过大的模型可能导致系统过载甚至卡死。",
+  "loader.guardrails.notEnoughResources.alwaysAllowLoadAnyway": "（不推荐）始终允许“仍然加载”，无需按住 Alt/Option"
 }

--- a/zh-CN/settings.json
+++ b/zh-CN/settings.json
@@ -2,7 +2,6 @@
   "settingsDialogTitle": "应用设置",
   "settingsDialogButtonTooltip": "应用设置",
   "accountDialogButtonTooltip": "账户",
-
   "settingsNewButtonPopover": {
     "primary": "应用设置现已移至右下角",
     "secondary": "点击⚙️按钮来打开",
@@ -58,7 +57,6 @@
   "chat/alwaysShowPromptTemplate": "始终在聊天侧栏显示提示模板",
   "chat/highlightChatMessageOnHover": "鼠标悬停时高亮显示聊天消息",
   "chat/doubleClickMessageToEdit": "双击聊天消息以编辑",
-
   "chat/aiNaming/label": "AI命名聊天",
   "chat/aiNaming/mode/label": "AI生成的聊天名称",
   "chat/aiNaming/mode/value/never": "关闭",
@@ -72,13 +70,11 @@
   "chat/keyboardShortcuts/verbPrefix": "使用",
   "chat/keyboardShortcuts/regenerate": "重新生成聊天中的最后一条消息",
   "chat/keyboardShortcuts/sendMessage": "发送消息",
-
   "onboarding/blockTitle": "新手引导",
   "onboarding/dismissedHints": "已关闭的新手引导",
   "onboarding/resetHintTooltip": "点击以重新启用新手引导",
   "onboarding/resetAllHints": "重置所有新手引导",
   "onboarding/noneDismissed": "没有已关闭的提示，目前所有提示项都会显示，直至下次关闭",
-
   "firstTimeExperienceLabel": "首次聊天体验",
   "firstTimeExperienceMarkCompletedLabel": "标记为已完成",
   "firstTimeExperienceResetLabel": "重置",
@@ -98,24 +94,20 @@
   "autoLoadBundledLLMLabel": "启动时自动加载捆绑的大语言模型",
   "showReleaseNotes": "显示发行说明",
   "hideReleaseNotes": "隐藏发行说明",
-
   "backendDownloadNewUpdate": "有新的后端可用！",
   "backendDownloadNewUpdateAction": "前往开发者页面",
-
   "backendDownloadChannel.label": "LM Studio 扩展包下载频道",
   "backendDownloadChannel.value.stable": "稳定版",
   "backendDownloadChannel.value.beta": "测试版",
   "backendDownloadChannel.value.latest": "开发版",
   "backendDownloadChannel.shortLabel": "运行环境下载频道",
   "backendDownloadChannel.hint": "选择从哪个频道下载 LM Studio 扩展包。\"{{stableName}}\" 是推荐给大多数用户的通道。",
-
   "appUpdateChannel.label": "LM Studio 更新频道",
   "appUpdateChannel.value.stable": "稳定版",
   "appUpdateChannel.value.beta": "beta测试版",
   "appUpdateChannel.value.alpha": "alpha测试版",
   "appUpdateChannel.shortLabel": "应用更新频道",
   "appUpdateChannel.hint": "选择从哪个频道接收 LM Studio 应用更新。\"{{stableName}}\" 是推荐给大多数用户的通道。",
-
   "modelLoadingGuardrails.label": "模型加载保护",
   "modelLoadingGuardrails.description": "超出系统资源限制加载模型可能导致系统不稳定或卡死。保护措施可以防止意外过载。如果需要，可以在这里调整这些限制。但请注意，接近系统极限加载模型可能会降低稳定性。",
   "modelLoadingGuardrails.value.off": "关闭（不推荐）",
@@ -136,10 +128,8 @@
   "modelLoadingGuardrails.custom.label": "内存限制：",
   "modelLoadingGuardrails.custom.unitGB": "GB",
   "modelLoadingGuardrails.custom.description": "为模型加载设置自定义内存限制。如果加载的模型会超过此限制，则不会加载模型。",
-
   "experimentalLoadPresets": "在预设中启用模型加载配置支持",
   "experimentalLoadPresets.description": "是否允许预设包含模型加载配置。此功能尚处于试验阶段，我们欢迎反馈。",
-
   "unloadPreviousJITModelOnLoad": "模型自动卸载：始终仅允许一个JIT模型加载（加载新模型时卸载上一个）",
   "autoDeleteExtensionPacks": "自动删除最近最少使用的运行环境扩展包",
   "autoUpdateExtensionPacks": "自动更新选中运行环境扩展包",
@@ -147,16 +137,12 @@
   "useHFProxy.hint": "使用 LM Studio 提供的 Hugging Face 代理进行模型搜索和下载。适用于无法直接访问 Hugging Face 的用户。",
   "separateReasoningContentInResponses": "在API响应中区分 `reasoning_content` 和 `content`（如适用）",
   "separateReasoningContentInResponses/hint": "该设置仅适用于像 DeepSeek R1 及其蒸馏模型等输出带有 <think> 和 </think> 标记的推理模型。",
-
   "promptWhenCommittingUnsavedChangesWithNewFields": "提交新字段到预设时显示确认对话框",
   "promptWhenCommittingUnsavedChangesWithNewFields.description": "如果您想避免意外向预设添加新字段，这将非常有用",
-
   "enableLocalService": "启用本地 LLM 服务",
   "enableLocalService.subtitle": "使用 LM Studio 的 LLM 服务器，而无需保持 LM Studio 应用程序打开",
   "enableLocalService.description": "启用时，LM Studio 本地 LLM 服务将自动启动。关闭 LM Studio 时，本地 LLM 服务也将在系统托盘中继续运行。",
-
   "expandConfigsOnClick": "点击而非悬停时展开配置",
-
   "migrateChats": {
     "label": "迁移 0.3.0 之前的聊天记录",
     "hasBetterLabel": "重新迁移 0.3.0 之前的聊天记录",
@@ -191,5 +177,23 @@
       "warnDescription": "禁用工具调用确认非常危险。如果您的插件中包含可能执行破坏性操作的工具（例如运行命令、删除文件、覆盖文件、上传文件等），模型将无需确认即可执行这些操作。您可以通过逐个工具或逐个插件的方式禁用确认提示。强烈不建议启用此选项。请谨慎操作。",
       "warnButton": "我了解风险"
     }
+  },
+  "appNavigationBarPositionLabel": "导航栏位置",
+  "appNavigationBarPositionTop": "顶部",
+  "appNavigationBarPositionLeft": "左侧",
+  "modelDefaultsLabel": "模型默认值",
+  "modelLoadingGuardrails.alwaysAllowLoadAnyway": "（不推荐）始终允许“仍然加载”，无需按住 Alt/Option",
+  "defaultContextLength": {
+    "label": "默认上下文长度",
+    "maxTitle": "模型最大值",
+    "customTitle": "自定义值",
+    "maxSubtitle": "对每个模型使用其支持的最大上下文长度。",
+    "customSubtitle": "为加载新模型设置默认上下文长度。若模型支持的最大上下文长度更小，将使用该更小值。",
+    "invalidNaNError": "无效的上下文长度。将使用 {{value}}",
+    "invalidRangeError": "无效的上下文长度。应在 1 到 2^30 范围内。将使用 {{value}}",
+    "largeContextWarning": "上下文长度越高，模型占用内存越大。如无必要，请勿修改默认值"
+  },
+  "jitTTL": {
+    "subtitle": "通过 JIT 加载的模型在空闲达到指定时长后将自动卸载。"
   }
 }

--- a/zh-CN/shared.json
+++ b/zh-CN/shared.json
@@ -1,6 +1,5 @@
 {
   "copyLmStudioLinkButton/toolTip": "复制模型下载链接",
-
   "filter.noMatches": "没有匹配项",
   "longRunningTask": {
     "unbundlingDependencies": {
@@ -34,7 +33,6 @@
     "fetchError": "获取工件失败",
     "organizationVisible": "组织可见"
   },
-
   "incompatible": "不兼容",
   "compatible": "兼容",
   "public": "公开",
@@ -42,7 +40,6 @@
   "yes": "是",
   "no": "否",
   "go": "开始",
-
   "proceedWithEllipsis": "继续...",
   "proceed": "继续",
   "inProgress": "进行中...",
@@ -50,7 +47,6 @@
   "pending": "待处理",
   "doneWithExclamation": "完成！",
   "done": "完成",
-
   "complete": {
     "completeWithEllipsis": "完成...",
     "complete": "完成",
@@ -59,7 +55,6 @@
     "completedWithExclamation": "已完成！",
     "completed": "已完成"
   },
-
   "cancel": {
     "cancelWithEllipsis": "取消...",
     "cancel": "取消",
@@ -67,17 +62,14 @@
     "canceling": "取消中",
     "canceled": "已取消"
   },
-
   "next": {
     "nextWithEllipsis": "下一步...",
     "next": "下一步"
   },
-
   "back": {
     "backWithEllipsis": "返回...",
     "back": "返回"
   },
-
   "close": {
     "closeWithEllipsis": "关闭...",
     "close": "关闭",
@@ -86,7 +78,6 @@
     "closedWithExclamation": "已关闭！",
     "closed": "已关闭"
   },
-
   "delete": {
     "deleteWithEllipsis": "删除...",
     "delete": "删除",
@@ -95,14 +86,12 @@
     "deletedWithExclamation": "已删除！",
     "deleted": "已删除"
   },
-
   "retry": {
     "retryWithEllipsis": "重试...",
     "retry": "重试",
     "retryingWithEllipsis": "重试中...",
     "retrying": "重试中"
   },
-
   "refresh": {
     "refreshWithEllipsis": "刷新...",
     "refresh": "刷新",
@@ -111,7 +100,6 @@
     "refreshedWithExclamation": "已刷新！",
     "refreshed": "已刷新"
   },
-
   "confirm": {
     "confirm": "确认",
     "confirmingWithEllipsis": "确认中...",
@@ -119,7 +107,6 @@
     "confirmedWithExclamation": "已确认！",
     "confirmed": "已确认"
   },
-
   "copy": {
     "copyWithEllipsis": "复制...",
     "copy": "复制",
@@ -128,7 +115,6 @@
     "copiedWithExclamation": "已复制！",
     "copied": "已复制"
   },
-
   "edit": {
     "editWithEllipsis": "编辑...",
     "edit": "编辑",
@@ -137,7 +123,6 @@
     "editedWithExclamation": "已编辑！",
     "edited": "已编辑"
   },
-
   "load": {
     "loadWithEllipsis": "加载...",
     "load": "加载",
@@ -146,7 +131,6 @@
     "loadedWithExclamation": "已加载！",
     "loaded": "已加载"
   },
-
   "save": {
     "saveWithEllipsis": "保存...",
     "save": "保存",
@@ -155,24 +139,20 @@
     "savedWithExclamation": "已保存！",
     "saved": "已保存"
   },
-
   "saveAs": {
     "saveAsWithEllipsis": "另存为...",
     "saveAs": "另存为"
   },
-
   "saveAsNew": {
     "saveAsNewWithEllipsis": "保存为新文件...",
     "saveAsNew": "保存为新文件"
   },
-
   "search": {
     "searchWithEllipsis": "搜索...",
     "search": "搜索",
     "searchingWithEllipsis": "搜索中...",
     "searching": "搜索中"
   },
-
   "update": {
     "updateWithEllipsis": "更新...",
     "update": "更新",
@@ -181,7 +161,6 @@
     "updatedWithExclamation": "已更新！",
     "updated": "已更新"
   },
-
   "create": {
     "createWithEllipsis": "创建...",
     "create": "创建",
@@ -190,21 +169,18 @@
     "createdWithExclamation": "已创建！",
     "created": "已创建"
   },
-
   "reset": {
     "resetWithEllipsis": "重置...",
     "reset": "重置",
     "resettingWithEllipsis": "重置中...",
     "resetting": "重置中"
   },
-
   "pause": {
     "pause": "暂停",
     "pausingWithEllipsis": "暂停中...",
     "pausing": "暂停中",
     "paused": "已暂停"
   },
-
   "download": {
     "download": "下载",
     "downloadingWithEllipsis": "下载中...",
@@ -212,7 +188,6 @@
     "downloadedWithExclamation": "已下载！",
     "downloaded": "已下载"
   },
-
   "upload": {
     "uploadWithEllipsis": "上传...",
     "upload": "上传",
@@ -221,7 +196,6 @@
     "uploadedWithExclamation": "已上传！",
     "uploaded": "已上传"
   },
-
   "remove": {
     "removeWithEllipsis": "移除...",
     "remove": "移除",
@@ -230,7 +204,6 @@
     "removedWithExclamation": "已移除！",
     "removed": "已移除"
   },
-
   "uninstall": {
     "uninstallWithEllipsis": "卸载...",
     "uninstall": "卸载",
@@ -239,14 +212,12 @@
     "uninstalledWithExclamation": "已卸载！",
     "uninstalled": "已卸载"
   },
-
   "resume": {
     "resumeWithEllipsis": "继续...",
     "resume": "继续",
     "resumingWithEllipsis": "继续中...",
     "resuming": "继续中"
   },
-
   "start": {
     "startWithEllipsis": "启动...",
     "start": "启动",
@@ -254,7 +225,6 @@
     "starting": "启动中",
     "started": "已启动"
   },
-
   "stop": {
     "stopWithEllipsis": "停止...",
     "stop": "停止",
@@ -263,7 +233,6 @@
     "stoppedWithExclamation": "已停止！",
     "stopped": "已停止"
   },
-
   "import": {
     "importWithEllipsis": "导入...",
     "import": "导入",
@@ -272,27 +241,23 @@
     "importedWithExclamation": "已导入！",
     "imported": "已导入"
   },
-
   "letsGo": {
     "letsGo": "开始吧",
     "letsGoWithEllipsis": "开始吧...",
     "letsGoWithExclamation": "开始吧！"
   },
-
   "run": {
     "runWithEllipsis": "运行...",
     "run": "运行",
     "runningWithEllipsis": "运行中...",
     "running": "运行中"
   },
-
   "configure": {
     "configureWithEllipsis": "配置...",
     "configure": "配置",
     "configuringWithEllipsis": "配置中...",
     "configured": "已配置"
   },
-
   "publish": {
     "publishWithEllipsis": "发布...",
     "publish": "发布",
@@ -300,5 +265,6 @@
     "publishing": "发布中",
     "publishedWithExclamation": "已发布！",
     "published": "已发布"
-  }
+  },
+  "beta": "测试版"
 }


### PR DESCRIPTION
## Summary
- Sync `zh-CN` localization keys with the latest English source strings.
- Add missing translations in `chat`, `config`, `developer`, `models`, `settings`, and `shared` namespaces.
- Keep placeholders and structured keys aligned with upstream additions.

## Test plan
- [x] Compare `en` and `zh-CN` keysets and verify no missing keys.
- [x] Confirm JSON files remain valid after updates.
- [x] Verify repository lint diagnostics report no errors in modified files.