### PR TITLE
Update zh-CN translation for models.json

### DIFF
--- a/zh-CN/models.json
+++ b/zh-CN/models.json
@@ -32,6 +32,7 @@
   "loader.model.bundled": "捆绑",
   "action.cancel": "取消",
   "indexingOngoing": "正在索引模型... 这可能需要几秒钟",
+  "indexingPageLoaderText": "正在索引模型...",
   "index/error_one": "索引以下文件夹失败：",
   "index/error_other": "索引以下文件夹失败：",
   "badModels/title_one": "索引以下模型失败：",
@@ -95,6 +96,16 @@
   "loader.info.clickOnModelToLoad": "点击模型以加载",
   "loader.info.configureLoadParameters": "配置模型加载参数",
   "loader.info.activeGeneratorWarning": "您正在使用带有自定义生成器的插件。当前加载的模型是否适用于该插件，取决于生成器的具体实现方式",
+  "loader.guardrails.estimatedMemoryUsage": "预估内存占用",
+  "loader.guardrails.total": "总计",
+  "loader.guardrails.gpu": "GPU",
+  "loader.guardrails.unavailable": "此模型暂无可用的内存预估",
+  "loader.guardrails.notEnoughResources": "当前设置下资源不足，无法加载模型",
+  "loader.guardrails.notEnoughResources/options": "选项",
+  "loader.guardrails.notEnoughResources.moreInfoSection.appearsNotEnoughMemory": "您的系统似乎没有足够的内存来加载此模型。",
+  "loader.guardrails.notEnoughResources.moreInfoSection.ifYouBelieveThisIsIncorrect": "您可以在设置中调整模型加载守护规则，或按住 <altOptionKey /> 强制加载。",
+  "loader.guardrails.notEnoughResources.moreInfoSection.warning": "加载过大的模型可能导致系统过载甚至卡死。",
+  "loader.guardrails.notEnoughResources.alwaysAllowLoadAnyway": "（不推荐）始终允许\"仍然加载\"，无需按住 Alt/Option",
 
   "virtual": {
     "local": {
@@ -110,6 +121,12 @@
       "next": "下一步",
       "confirm": "创建",
       "error": "创建虚拟模型失败"
+    },
+    "altsSelect": {
+      "title": "切换模型来源",
+      "resetButton": "重置为默认值",
+      "description": "此模型有多个可用的源文件。",
+      "trigger": "变体"
     }
   }
 }


### PR DESCRIPTION
## Summary
补齐 `zh-CN/models.json` 中缺失的 15 个键，覆盖资源守护规则、内存预估、以及虚拟模型变体切换。

## Changes
- `indexingPageLoaderText` (1 键): 模型索引加载提示
- `loader.guardrails.*` (10 键): 资源守护、内存预估、Load Anyway 选项
- `virtual.altsSelect.*` (4 键): 虚拟模型变体来源切换

## Notes
- 保留专有名词不译：`GPU` / `Alt/Option` / `<altOptionKey />`
- 占位符 `{{xxx}}` 保留
- 沿用现有 zh-CN 风格（语体正式 "您"、Markdown 保留、emoji 保留）
- "guardrails" 统一译为"守护规则"