### PR TITLE
Update zh-CN translations for chat, settings, shared

### DIFF
--- a/zh-CN/chat.json
+++ b/zh-CN/chat.json
@@ -60,6 +60,8 @@
   "actions/loadLastModel": "重新加载上次使用的模型",
   "actions/loadLastModel/tooltip": "点击以加载上次与该聊天一起使用的模型：\n\n{{lastModel}}",
   "actions/loadLastModel/error": "加载上次使用的模型失败。",
+  "actions/clearLastUsedModel": "清除最后使用的模型",
+  "actions/clearLastUsedModel/error": "清除最后使用的模型失败。",
   "actions/continueCurrentModel": "使用当前模型",
   "actions/continueCurrentModel/tooltip": "当前模型：{{currentModel}}",
   "actions/changeToLastUsedModel": "加载 {{lastModel}}",
@@ -192,7 +194,9 @@
       },
       "startRunningDevelopmentPlugin/error": "开发模式插件启动失败",
       "stopRunningDevelopmentPlugin/error": "开发模式插件停止失败",
-      "forceReInitPlugin/error": "重启插件失败"
+      "forceReInitPlugin/error": "重启插件失败",
+      "signOutMcpPlugin/error": "退出插件失败",
+      "cancelMcpAuthentication/error": "取消插件身份验证失败"
     },
     "pluginConfiguration": {
       "title": "插件配置",
@@ -237,7 +241,9 @@
     "stopReason.maxPredictedTokensReached": "达到最大预测词元",
     "stopReason.contextLengthReached": "达到上下文长度上限",
     "speculativeDecodedBy": "草稿模型：{{decodedBy}}",
-    "speculativeDecodingStats": "已采纳 {{accepted}}/{{total}} 个草稿token（{{percentage}}%）"
+    "speculativeDecodingStats": "已采纳 {{accepted}}/{{total}} 个草稿token（{{percentage}}%）",
+    "speculativeDecodingAcceptedPercentage": "{{percentage}}% 的草稿 token 已被采纳",
+    "speculativeDecodingTooltip": "已采纳 {{accepted}}/{{total}} 个草稿 token"
   },
 
   "tabs": {

--- a/zh-CN/settings.json
+++ b/zh-CN/settings.json
@@ -49,6 +49,9 @@
   "sideButtonLabels": "显示侧边按钮标签",
   "showModelFileNames": "在“我的模型”中始终显示完整模型文件名",
   "colorThemeLabel": "颜色主题",
+  "appNavigationBarPositionLabel": "导航栏位置",
+  "appNavigationBarPositionTop": "顶部",
+  "appNavigationBarPositionLeft": "左侧",
   "complexityLevelLabel": "用户界面复杂度级别",
   "selectComplexityLevelPlaceholder": "选择默认的UI复杂度级别",
   "userComplexityLevelLabel": "普通用户",
@@ -92,6 +95,7 @@
   "changeLanguageLabel": "选择应用语言（仍在开发中）",
   "developerLabel": "开发者",
   "localServiceLabel": "本地 LLM 服务（无界面）",
+  "modelDefaultsLabel": "模型默认值",
   "showExperimentalFeaturesLabel": "显示实验性功能",
   "appFirstLoadLabel": "应用首次加载体验",
   "showDebugInfoBlocksInChatLabel": "在聊天中显示调试信息块",
@@ -136,6 +140,7 @@
   "modelLoadingGuardrails.custom.label": "内存限制：",
   "modelLoadingGuardrails.custom.unitGB": "GB",
   "modelLoadingGuardrails.custom.description": "为模型加载设置自定义内存限制。如果加载的模型会超过此限制，则不会加载模型。",
+  "modelLoadingGuardrails.alwaysAllowLoadAnyway": "（不推荐）始终允许\"仍然加载\"，无需按住 Alt/Option",
 
   "experimentalLoadPresets": "在预设中启用模型加载配置支持",
   "experimentalLoadPresets.description": "是否允许预设包含模型加载配置。此功能尚处于试验阶段，我们欢迎反馈。",
@@ -191,5 +196,19 @@
       "warnDescription": "禁用工具调用确认非常危险。如果您的插件中包含可能执行破坏性操作的工具（例如运行命令、删除文件、覆盖文件、上传文件等），模型将无需确认即可执行这些操作。您可以通过逐个工具或逐个插件的方式禁用确认提示。强烈不建议启用此选项。请谨慎操作。",
       "warnButton": "我了解风险"
     }
+  },
+
+  "defaultContextLength": {
+    "label": "默认上下文长度",
+    "maxTitle": "模型最大值",
+    "customTitle": "自定义值",
+    "maxSubtitle": "使用每个模型支持的最大上下文长度。",
+    "customSubtitle": "为加载新模型设置默认上下文长度。如果模型支持的最大上下文长度更小，则使用该值。",
+    "invalidNaNError": "无效的上下文长度值。将使用 {{value}}",
+    "invalidRangeError": "无效的上下文长度值。应介于 1 到 2^30 之间。将使用 {{value}}",
+    "largeContextWarning": "上下文长度越长，模型占用的内存越多。如有疑问，请勿修改默认值"
+  },
+  "jitTTL": {
+    "subtitle": "JIT（即时）加载的模型在空闲指定时长后将被自动卸载。"
   }
 }

--- a/zh-CN/shared.json
+++ b/zh-CN/shared.json
@@ -50,6 +50,7 @@
   "pending": "待处理",
   "doneWithExclamation": "完成！",
   "done": "完成",
+  "beta": "Beta",
 
   "complete": {
     "completeWithEllipsis": "完成...",


### PR DESCRIPTION
## Summary
收尾补齐 `zh-CN/chat.json` + `settings.json` + `shared.json` 中剩余的 21 个缺失键。

## Changes
**chat.json** (+6 键):
- `actions/clearLastUsedModel*` (2): 清除最后使用模型
- `plugins.pluginSelect.signOutMcpPlugin/error` + `cancelMcpAuthentication/error` (2): MCP 插件错误
- `genInfo.speculativeDecodingAcceptedPercentage` + `Tooltip` (2): 投机解码统计

**settings.json** (+14 键):
- `appNavigationBarPosition*` (3): 导航栏位置（顶/左）
- `modelDefaultsLabel` (1): 模型默认值区块
- `modelLoadingGuardrails.alwaysAllowLoadAnyway` (1): 始终允许强制加载
- `defaultContextLength.*` (8): 默认上下文长度（标签、最大值、自定义、错误提示）
- `jitTTL.subtitle` (1): JIT 自动卸载说明

**shared.json** (+1 键):
- `beta`: "Beta"（品牌术语保留）

## Notes
- 保留专有名词不译：`Beta` / `GPU` / `CPU` / `JIT` / `Alt/Option` / `2^30`
- 占位符 `{{xxx}}` 保留
- 沿用现有 zh-CN 风格（"您"语体、Markdown/链接保留）