### PR TITLE
Fix zh-CN terminology: align 未提交 with 未保存 in config.json

### DIFF
--- a/zh-CN/config.json
+++ b/zh-CN/config.json
@@ -355,7 +355,7 @@
   },
   "applyConflictResolution": {
     "title": "保留哪些值？",
-    "description": "您有未提交的更改与即将应用的预设有重叠",
+    "description": "您有未保存的更改与即将应用的预设有重叠",
     "instructions": "点击一个值以保留它",
     "userValues": "当前值",
     "presetValues": "即将应用的预设值",
@@ -399,7 +399,7 @@
     "select/error": "选择预设失败。",
     "delete/error": "删除预设失败。",
     "discardChanges": "丢弃未保存的更改",
-    "discardChanges/info": "丢弃所有未提交的更改并恢复预设至原始状态",
+    "discardChanges/info": "丢弃所有未保存的更改并恢复预设至原始状态",
     "newEmptyPreset": "创建新的空预设...",
     "importPreset": "导入",
     "contextMenuCopyIdentifier": "复制预设标识符",


### PR DESCRIPTION
## Summary
跟随 PR #406 的命名升级,清理 zh-CN 中 2 处仍使用"未提交"措辞的键,统一为"未保存"。

## Changes
**zh-CN/config.json** (2 keys):
- `applyConflictResolution.description`: "未提交的更改" → "未保存的更改"
- `presets.discardChanges/info`: "未提交的更改" → "未保存的更改"

## Notes
- 与 en 的 `Discard all unsaved changes` 用词对齐
- 与同文件 `presets.discardChanges` ("丢弃未保存的更改") 一致
- en 原文此处写作 "uncommitted" (与文件内其他 "unsaved" 不一致),保留 en 不动,仅统一 zh-CN