### PR TITLE
i18n(zh-TW): complete zh-TW translations for chat and settings

### DIFF
--- a/zh-TW/chat.json
+++ b/zh-TW/chat.json
@@ -60,6 +60,8 @@
   "actions/loadLastModel": "重新載入上次使用的模型",
   "actions/loadLastModel/tooltip": "點擊以載入與此聊天上次使用的模型：\n\n{{lastModel}}",
   "actions/loadLastModel/error": "重新載入上次使用的模型失敗。",
+  "actions/clearLastUsedModel": "清除上次使用的模型",
+  "actions/clearLastUsedModel/error": "清除上次使用的模型失敗。",
   "actions/continueCurrentModel": "使用目前模型",
   "actions/continueCurrentModel/tooltip": "目前模型：{{currentModel}}",
   "actions/changeToLastUsedModel": "載入 {{lastModel}}",
@@ -155,6 +157,9 @@
     }
   },
 
+  "chatTabOptions/clearAllMessages": "清除所有訊息...",
+  "chatTabOptions/duplicateChat": "複製聊天",
+
   "topBarActions/duplicateChat": "複製",
   "topBarActions/clearChat": "清除全部",
   "topBarActions/clearChatConfirmation": "您確定要清除此對話中的所有訊息嗎？",
@@ -189,7 +194,9 @@
       },
       "startRunningDevelopmentPlugin/error": "啟動開發模式插件失敗",
       "stopRunningDevelopmentPlugin/error": "停止開發模式插件執行失敗",
-      "forceReInitPlugin/error": "重新啟動插件失敗"
+      "forceReInitPlugin/error": "重新啟動插件失敗",
+      "signOutMcpPlugin/error": "登出插件失敗",
+      "cancelMcpAuthentication/error": "取消插件身分驗證失敗"
     },
     "pluginConfiguration": {
       "title": "插件設定",
@@ -234,7 +241,9 @@
     "stopReason.maxPredictedTokensReached": "達到最大預測 Token 數量",
     "stopReason.contextLengthReached": "達到上下文長度限制",
     "speculativeDecodedBy": "草稿模型: {{decodedBy}}",
-    "speculativeDecodingStats": "接受了 {{accepted}}/{{total}} 個草稿 Token ({{percentage}}%)"
+    "speculativeDecodingStats": "接受了 {{accepted}}/{{total}} 個草稿 Token ({{percentage}}%)",
+    "speculativeDecodingAcceptedPercentage": "已接受 {{percentage}}% 的草稿 Token",
+    "speculativeDecodingTooltip": "已接受 {{accepted}}/{{total}} 個草稿 Token"
   },
 
   "tabs": {

--- a/zh-TW/settings.json
+++ b/zh-TW/settings.json
@@ -49,6 +49,9 @@
   "sideButtonLabels": "顯示側邊按鈕標籤",
   "showModelFileNames": "我的模型：總是顯示完整的模型檔案名稱",
   "colorThemeLabel": "色彩主題",
+  "appNavigationBarPositionLabel": "導覽列位置",
+  "appNavigationBarPositionTop": "頂部",
+  "appNavigationBarPositionLeft": "左側",
   "complexityLevelLabel": "使用者介面複雜度等級",
   "selectComplexityLevelPlaceholder": "選擇預設的 UI 複雜度等級",
   "userComplexityLevelLabel": "使用者",
@@ -92,6 +95,7 @@
   "changeLanguageLabel": "選擇應用程式語言 (仍在開發中)",
   "developerLabel": "開發者",
   "localServiceLabel": "本機 LLM 服務 (無頭模式)",
+  "modelDefaultsLabel": "模型預設值",
   "showExperimentalFeaturesLabel": "顯示實驗性功能",
   "appFirstLoadLabel": "應用程式首次載入體驗",
   "showDebugInfoBlocksInChatLabel": "在聊天中顯示除錯資訊區塊",
@@ -136,6 +140,7 @@
   "modelLoadingGuardrails.custom.label": "記憶體限制：",
   "modelLoadingGuardrails.custom.unitGB": "GB",
   "modelLoadingGuardrails.custom.description": "設定模型載入的自訂記憶體限制。 如果載入模型會超過此限制，則不會載入。",
+  "modelLoadingGuardrails.alwaysAllowLoadAnyway": "（不建議）一律允許「仍要載入」，無需按住 Alt/Option 鍵",
 
   "experimentalLoadPresets": "啟用預設配置中模型載入支援",
   "experimentalLoadPresets.description": "是否允許預設包含模型載入配置。 此功能是實驗性的，我們歡迎您的回饋。",
@@ -181,6 +186,19 @@
     "hasBetterFooterCardText": "自您遷移了舊的聊天以來，我們已經改進了聊天遷移器。您可以重新執行遷移過程。（我們會創建一個新的資料夾來包含新遷移的聊天。）",
     "dismissConfirm": "關閉",
     "dismissConfirmDescription": "您可以在設定中隨時處理聊天遷移。"
+  },
+  "defaultContextLength": {
+    "label": "預設上下文長度",
+    "maxTitle": "模型上限",
+    "customTitle": "自訂值",
+    "maxSubtitle": "使用每個模型支援的最大上下文長度。",
+    "customSubtitle": "設定載入新模型時的預設上下文長度。如果模型支援的最大上下文長度較小，則會使用該值。",
+    "invalidNaNError": "無效的上下文長度值。使用 {{value}}",
+    "invalidRangeError": "無效的上下文長度值。應介於 1 到 2^30 之間。使用 {{value}}",
+    "largeContextWarning": "上下文長度越高，模型佔用的記憶體就越多。如果您不確定，請不要變更預設值"
+  },
+  "jitTTL": {
+    "subtitle": "JIT 載入的模型在閒置指定時間後將自動卸載。"
   },
   "toolConfirmation": {
     "label": "工具呼叫確認",


### PR DESCRIPTION
zh-TW chat.json 与 settings.json 同步 en 版本。

**chat.json — 8 个新增**
- actions/clearLastUsedModel + error
- chatTabOptions/clearAllMessages + duplicateChat
- plugins/pluginSelect/signOutMcpPlugin + cancelMcpAuthentication/errors
- genInfo/speculativeDecodingAcceptedPercentage + speculativeDecodingTooltip

**settings.json — 14 个新增**
- appNavigationBarPosition* (3 keys)
- modelDefaultsLabel
- modelLoadingGuardrails.alwaysAllowLoadAnyway
- defaultContextLength (8 keys nested)
- jitTTL/subtitle

完成后：chat.json 100%；settings.json 100%。与 #408、#409 互补，分别为文件级独立 PR。